### PR TITLE
cloudwatch-logs-s3-bucket

### DIFF
--- a/tf-modules/cloudwatch-logs-s3-bucket/iam.tf
+++ b/tf-modules/cloudwatch-logs-s3-bucket/iam.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "cloudwatch-logs-writer" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "logs:putLogEvents",
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch-logs-writer-trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cloudwatch-logs-writer" {
+  name               = "cloudwatch_logs_writer"
+  path               = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.cloudwatch-logs-writer-trust.json}"
+}
+
+resource "aws_iam_role_policy" "cloudwatch-logs-writer" {
+  name   = "cloudwach_logs_writer_policy"
+  role   = "${aws_iam_role.cloudwatch-logs-writer.id}"
+  policy = "${data.aws_iam_policy_document.cloudwatch-logs-writer.json}"
+}
+
+resource "aws_iam_instance_profile" "cloudwatch-logs-writer" {
+  name = "cloudwatch_logs_writer"
+  role = "${aws_iam_role.cloudwatch-logs-writer.name}"
+}

--- a/tf-modules/cloudwatch-logs-s3-bucket/main.tf
+++ b/tf-modules/cloudwatch-logs-s3-bucket/main.tf
@@ -2,12 +2,14 @@
  * ## CloudWatch Logs S3 Bucket
  *
  * This module creates an S3 bucket with correct IAM policies for
- * shipping instance logs using CloudWatch. Users of this module need
- * to create `aws_cloudwatch_log_group` separately and provide ARNs of
- * writers so permission is granted for writing.
+ * shipping instance logs using CloudWatch. Users of this module may
+ * create `aws_cloudwatch_log_group` separately and provide ARNs of
+ * writers's service accounts so permission is granted for writing, or
+ * attach the IAM instance profiles directly. These profiles allow for
+ * instances to create log groups and log streams.
  *
  * Logs are append-only by design. No permission is given to writers
- * to retrieve or alter any objects.
+ * to alter any objects.
  *
  * ### Example
  *
@@ -29,7 +31,7 @@
  *
  */
 
-data "aws_iam_policy_document" "cloudwatch-logs-writer" {
+data "aws_iam_policy_document" "cloudwatch-logs-bucket" {
   statement {
     effect  = "Allow"
     actions = ["s3:PutObject"]
@@ -46,7 +48,7 @@ data "aws_iam_policy_document" "cloudwatch-logs-writer" {
 resource "aws_s3_bucket" "cloudwatch-logs" {
   bucket = "${var.name_prefix}-cloudwatch-logs"
   acl    = "private"
-  policy = "${data.aws_iam_policy_document.cloudwatch-logs-writer.json}"
+  policy = "${length(var.principals) == 0 ? "" : data.aws_iam_policy_document.cloudwatch-logs-writer.json}"
 
   tags = "${merge(map("Name","${var.name_prefix}-cloudwatch-logs"), "${var.extra_tags}")}"
 }

--- a/tf-modules/cloudwatch-logs-s3-bucket/main.tf
+++ b/tf-modules/cloudwatch-logs-s3-bucket/main.tf
@@ -1,0 +1,52 @@
+/**
+ * ## CloudWatch Logs S3 Bucket
+ *
+ * This module creates an S3 bucket with correct IAM policies for
+ * shipping instance logs using CloudWatch. Users of this module need
+ * to create `aws_cloudwatch_log_group` separately and provide ARNs of
+ * writers so permission is granted for writing.
+ *
+ * Logs are append-only by design. No permission is given to writers
+ * to retrieve or alter any objects.
+ *
+ * ### Example
+ *
+ * ```
+ * # Service account of ELB where writer instances are located
+ * data "aws_elb_service_account" "current" {}
+ *
+ * # Basic log group
+ * resource "aws_cloudwatch_log_group" "syslog" {
+ *   name = "syslog"
+ * }
+ *
+ * module "cloudwatch-logs" {
+ *   source      = "github.com/fpco/fpco-terraform-aws//tf-modules/cloudwatch-logs"
+ *   name_prefix = "some-project"
+ *   principals  = ["${data.aws_elb_service_account.current.arn}"]
+ * }
+ * ```
+ *
+ */
+
+data "aws_iam_policy_document" "cloudwatch-logs-writer" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+
+    resources = ["arn:${var.aws_region}:s3:::${var.name_prefix}-cloudwatch-logs/*}"]
+
+    principals {
+      type        = "AWS"
+      identifiers = "${var.principals}"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "cloudwatch-logs" {
+  bucket = "${var.name_prefix}-cloudwatch-logs"
+  acl    = "private"
+  policy = "${data.aws_iam_policy_document.cloudwatch-logs-writer.json}"
+
+  tags = "${merge(map("Name","${var.name_prefix}-cloudwatch-logs"), "${var.extra_tags}")}"
+}

--- a/tf-modules/cloudwatch-logs-s3-bucket/outputs.tf
+++ b/tf-modules/cloudwatch-logs-s3-bucket/outputs.tf
@@ -1,0 +1,9 @@
+# id of S3 bucket
+output "s3_bucket_id" {
+  value = "${aws_s3_bucket.cloudwatch-logs.id}"
+}
+
+# ARN of S3 bucket
+output "s3_bucket_arn" {
+  value = "${aws_s3_bucket.cloudwatch-logs.arn}"
+}

--- a/tf-modules/cloudwatch-logs-s3-bucket/outputs.tf
+++ b/tf-modules/cloudwatch-logs-s3-bucket/outputs.tf
@@ -7,3 +7,13 @@ output "s3_bucket_id" {
 output "s3_bucket_arn" {
   value = "${aws_s3_bucket.cloudwatch-logs.arn}"
 }
+
+# IAM instance profile for log writers
+output "iam_instance_profile_name" {
+  value = "${aws_iam_instance_profile.cloudwatch-logs-writer.name}"
+}
+
+# Instances IAM role document for use with user-defined role policies.
+output "iam_role_policy_json" {
+  value = "${data.aws_iam_policy_document.cloudwatch-logs-writer.json}"
+}

--- a/tf-modules/cloudwatch-logs-s3-bucket/variables.tf
+++ b/tf-modules/cloudwatch-logs-s3-bucket/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  description = "AWS partition where this is running. Unless running on GovCloud, leave as default"
+  default     = "aws"
+}
+
+variable "name_prefix" {
+  description = "Name to prefix to S3 bucket with CloudWatch logs"
+}
+
+variable "principals" {
+  description = "List of principals’ ARNs"
+  type        = "list"
+}
+
+variable "extra_tags" {
+  description = "Tags to apply on S3 bucket. Name is automatically created, so no need to pass it."
+  type        = "map"
+  default     = {}
+}


### PR DESCRIPTION
Adds a module with documentation for creating S3 buckets for CloudWatch Logs, with necessary IAM.

User still has to create the Log Groups elsewhere and configure instances, as each caller might have different use cases and types of streams in mind.