### PR TITLE
Adds cloudwatch exporter iam

### DIFF
--- a/modules/cloudwatch-exporter-iam/README.md
+++ b/modules/cloudwatch-exporter-iam/README.md
@@ -1,0 +1,20 @@
+# Prometheus Cloudwatch exporter IAM role
+
+This module creates an `aws_iam_role` that get's assigned to the
+prometheus-cloudwatch pod so it's able to scrape cloudwatch
+metrics. For example: RDS Cpu Usage.
+
+Usage:
+
+    module "cloudwatch-exporter" {
+      source                 = "fpco/foundation/aws//modules/cloudwatch-exporter-iam"
+      version                = "0.7.0-rc3"
+      name_prefix            = "example"
+      kube_cluster_nodes_arn = "arn:aws:iam::ARN_FOR_KUBE_NODES"
+    }
+
+This is to be used in combo with [kube2iam](https://github.com/jtblin/kube2iam) for automatic assignment
+of aws iam roles to pods. Specifically, the pod that will need it is the [prometheus-cloudwatch](https://github.com/fpco/helm-charts/tree/master/prometheus-cloudwatch) pod.
+See our [foundation helm chart](https://github.com/fpco/helm-charts/tree/master/foundation) for an example
+on how to deploy `kube2iam` and `prometheus-cloudwatch`.
+

--- a/modules/cloudwatch-exporter-iam/data.tf
+++ b/modules/cloudwatch-exporter-iam/data.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "cloudwatch_exporter" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    sid = ""
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.kube_cluster_nodes_arn}"]
+    }
+  }
+}

--- a/modules/cloudwatch-exporter-iam/main.tf
+++ b/modules/cloudwatch-exporter-iam/main.tf
@@ -1,0 +1,26 @@
+/**
+ * ## Prometheus Cloudwatch exporter IAM role
+ *
+ * This role is for creating a IAM policy that can later get attached to the
+ * prometheus-cloudwatch exporter pod. To be used in combo with kube2iam.
+ *
+ */
+
+resource "aws_iam_role" "cloudwatch_exporter" {
+  name               = "${var.name_prefix}-cloudwatch-exporter"
+  path               = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.assume.json}"
+}
+
+resource "aws_iam_policy" "cloudwatch_exporter" {
+  name        = "${var.name_prefix}-cloudwatch-exporter"
+  path        = "/"
+  description = "Allows reading cloud watch metrics."
+
+  policy = "${data.aws_iam_policy_document.cloudwatch_exporter.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_exporter" {
+  role       = "${aws_iam_role.cloudwatch_exporter.name}"
+  policy_arn = "${aws_iam_policy.cloudwatch_exporter.arn}"
+}

--- a/modules/cloudwatch-exporter-iam/outputs.tf
+++ b/modules/cloudwatch-exporter-iam/outputs.tf
@@ -1,0 +1,10 @@
+output "name" {
+  value       = "${aws_iam_role.cloudwatch_exporter.name}"
+  description = "Name of the new role with cloudwatch read-only permissions."
+}
+
+output "arn" {
+  value       = "${aws_iam_role.cloudwatch_exporter.arn}"
+  description = "ARN of the new role with cloudwatch read-only permissions."
+}
+

--- a/modules/cloudwatch-exporter-iam/outputs.tf
+++ b/modules/cloudwatch-exporter-iam/outputs.tf
@@ -1,9 +1,9 @@
-output "name" {
+output "role_name" {
   value       = "${aws_iam_role.cloudwatch_exporter.name}"
   description = "Name of the new role with cloudwatch read-only permissions."
 }
 
-output "arn" {
+output "role_arn" {
   value       = "${aws_iam_role.cloudwatch_exporter.arn}"
   description = "ARN of the new role with cloudwatch read-only permissions."
 }

--- a/modules/cloudwatch-exporter-iam/variables.tf
+++ b/modules/cloudwatch-exporter-iam/variables.tf
@@ -1,0 +1,7 @@
+variable "name_prefix" {
+  description = "Name to prefix the resources with."
+}
+
+variable "kube_cluster_nodes_arn" {
+  description = "ARN of the Kube Nodes. Will be used in the iam policy identifier."
+}

--- a/modules/external-dns-iam/outputs.tf
+++ b/modules/external-dns-iam/outputs.tf
@@ -1,9 +1,9 @@
-output "name" {
+output "role_name" {
   value       = "${aws_iam_role.dnscontroller.name}"
   description = "Name of the new role with route53 permissions."
 }
 
-output "arn" {
+output "role_arn" {
   value       = "${aws_iam_role.dnscontroller.arn}"
   description = "ARN of the new role with route53 permissions."
 }

--- a/modules/external-dns-iam/outputs.tf
+++ b/modules/external-dns-iam/outputs.tf
@@ -1,9 +1,9 @@
-output "dnscontroller_iam_role" {
+output "name" {
   value       = "${aws_iam_role.dnscontroller.name}"
   description = "Name of the new role with route53 permissions."
 }
 
-output "dnscontroller_iam_role_arn" {
+output "arn" {
   value       = "${aws_iam_role.dnscontroller.arn}"
   description = "ARN of the new role with route53 permissions."
 }

--- a/modules/external-dns-iam/variables.tf
+++ b/modules/external-dns-iam/variables.tf
@@ -4,5 +4,4 @@ variable "name_prefix" {
 
 variable "kube_cluster_nodes_arn" {
   description = "ARN of the Kube Nodes. Will be used in the iam policy identifier."
-  default     = ""
 }


### PR DESCRIPTION
Same as with dnscontroller-iam. 

Also, adds a tiny fix for that role (dnscontroller) as well, to make it more consistent. 

Specifically the naming of the outputs should not be "some_elaborate_name_FOO" it should just be "foo" since the user will access it as "module.mydnscontroller.FOO". That's my thinking anyway. The only thing I'm not sure off is of the outputs should be `role_name` and `role_arn` or is `name` and `arn` good enough. 
What do we usually do in these cases?