### PR TITLE
Brought back ability to use ELBs for Elasticsearch and Kibana in ELK

### DIFF
--- a/modules/elasticsearch/data-nodes.tf
+++ b/modules/elasticsearch/data-nodes.tf
@@ -175,7 +175,7 @@ resource "aws_elb" "elasticsearch-external-elb" {
     instance_protocol = "http"
     lb_port = 9201
     lb_protocol = "https"
-    ssl_certificate_id = "${var.external_alb["certificate"]}"
+    ssl_certificate_id = "${var.external_alb["certificate_arn"]}"
   }
 
   cross_zone_load_balancing = "${lookup(var.internal_alb, "deploy_elb_cross_zone", true)}"
@@ -244,7 +244,7 @@ resource "aws_alb_listener" "elasticsearch-api-secured" {
   port              = 9201
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = "${var.external_alb["certificate"]}"
+  certificate_arn   = "${var.external_alb["certificate_arn"]}"
 
   default_action {
     target_group_arn = "${element(aws_alb_target_group.elasticsearch-api-secured.*.arn, 0)}"

--- a/modules/elasticsearch/networking.tf
+++ b/modules/elasticsearch/networking.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "elasticsearch-api-rule" {
   source_security_group_id = "${var.internal_alb["security_group_id"]}"
 }
 
-// Rule that allows ingress to ALB from the private subnet only
+// Rule that allows ingress to internal ALB from private subnets only
 resource "aws_security_group_rule" "internal-alb-rule" {
   security_group_id = "${var.internal_alb["security_group_id"]}"
   type              = "ingress"
@@ -73,7 +73,6 @@ resource "aws_security_group_rule" "elasticsearch-api-secured-rule" {
 resource "aws_security_group_rule" "external-alb-rule" {
   count = "${var.external_alb_setup ? 1 : 0}"
 
-  # TODO: check if fails without default "" and with empty `external_alb`.
   security_group_id = "${lookup(var.external_alb, "security_group_id", "")}"
   type              = "ingress"
   from_port         = 9201

--- a/modules/elasticsearch/outputs.tf
+++ b/modules/elasticsearch/outputs.tf
@@ -13,3 +13,21 @@ output "master_node_ebs_volume_ids" {
 output "data_node_ebs_volume_ids" {
   value = ["${module.data-node-ebs-volumes.volume_ids}"]
 }
+
+// Internal ELB related info. Will either be ELB or ALB info.
+output "internal_lb" {
+  value = {
+    "dns_name"          = "${element(coalescelist(aws_elb.elasticsearch-internal-elb.*.dns_name, list(lookup(var.internal_alb, "dns_name", ""))), 0)}"
+    "zone_id"           = "${element(coalescelist(aws_elb.elasticsearch-internal-elb.*.zone_id, list(lookup(var.internal_alb, "zone_id", ""))), 0)}"
+    "security_group_id" = "${var.internal_alb["security_group_id"]}"
+  }
+}
+
+// External ELB related info. Will either be ELB or ALB info.
+output "external_lb" {
+  value = {
+    "dns_name"          = "${element(coalescelist(aws_elb.elasticsearch-external-elb.*.dns_name, list(lookup(var.external_alb, "dns_name", ""))), 0)}"
+    "zone_id"           = "${element(coalescelist(aws_elb.elasticsearch-external-elb.*.zone_id, list(lookup(var.external_alb, "zone_id", ""))), 0)}"
+    "security_group_id" = "${lookup(var.external_alb, "security_group_id", "")}"
+  }
+}

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -128,6 +128,16 @@ variable "credstash_get_cmd" {
   description = "Credstash get command with region and table values set."
 }
 
+/**
+ Argument is expected to have this structure:
+  * security_group_id (required)
+  * deploy_elb (optional, default: false) - if set to true ELB will be deployed.
+  * deploy_elb_internal (optional, default: true) - if set to false ELB will be deployed as an external one.
+  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ for ELB will be off.
+  Below are only required if `deploy_elb` is set to `false` or ommited.
+  * arn - ALB ARN
+  * dns_name - host-header for ALB listener rule
+*/
 variable "internal_alb" {
   type        = "map"
   description = "Information about Internal ALB"
@@ -138,11 +148,9 @@ variable "external_alb_setup" {
   description = "Should an external access be allowed to ES API on port 9201 with HTTPS and BasicAuth."
 }
 
-variable "elasticsearch_dns_ssl_name" {
-  default     = ""
-  description = "DNS name for Elasticsearch endpoint SSL. An SSL certificate is expected to be present in ACM for this domain. If left empty 'elasticsearch_dns_name' will be checked instead."
-}
-
+/* Same as `internal_alb`, except also requires a "certificate" variable, which is an
+   ARN for an ISSUED ACM certificate
+*/
 variable "external_alb" {
   type        = "map"
   default     = {}

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -128,19 +128,23 @@ variable "credstash_get_cmd" {
   description = "Credstash get command with region and table values set."
 }
 
-/**
- Argument is expected to have this structure:
-  * security_group_id (required)
-  * deploy_elb (optional, default: false) - if set to true ELB will be deployed.
-  * deploy_elb_internal (optional, default: true) - if set to false ELB will be deployed as an external one.
-  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ for ELB will be off.
-  Below are only required if `deploy_elb` is set to `false` or ommited.
-  * arn - ALB ARN
-  * dns_name - host-header for ALB listener rule
-*/
 variable "internal_alb" {
   type        = "map"
-  description = "Information about Internal ALB"
+  description = <<DOC
+Information on already existing Application LB or settings for a Classic LB to
+be deployed:
+  * security_group_id (required)
+  * deploy_elb (optional, default: false) - if set to true ELB will be deployed
+    and used instead of an ALB.
+  * deploy_elb_internal (optional, default: true) - if set to false ELB will be
+    deployed as an external one.
+  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ
+    for ELB will be off.
+Below are only required if `deploy_elb` is set to `false` or omitted:
+  * arn - ALB ARN.
+  * dns_name - host-header for ALB listener rule.
+  * zone_id - not used directly, but will be returned in the `lb` output map.
+DOC
 }
 
 variable "external_alb_setup" {
@@ -148,13 +152,27 @@ variable "external_alb_setup" {
   description = "Should an external access be allowed to ES API on port 9201 with HTTPS and BasicAuth."
 }
 
-/* Same as `internal_alb`, except also requires a "certificate" variable, which is an
-   ARN for an ISSUED ACM certificate
-*/
 variable "external_alb" {
   type        = "map"
   default     = {}
-  description = "Information about External ALB"
+  description = <<DOC
+ This variable is unused, unless `external_alb_setup` is set to true. Information on already
+ existing Application LB or settings for a Classic LB to be deployed:
+Information on already existing Application LB or settings for a Classic LB to
+be deployed:
+  * certificate_arn (required) - ARN of ACM certificate to be used.
+  * security_group_id (required)
+  * deploy_elb (optional, default: false) - if set to true ELB will be deployed
+    and used instead of an ALB.
+  * deploy_elb_internal (optional, default: true) - if set to false ELB will be
+    deployed as an external one.
+  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ
+    for ELB will be off.
+Below are only required if `deploy_elb` is set to `false` or omitted:
+  * arn - ALB ARN.
+  * dns_name - host-header for ALB listener rule.
+  * zone_id - not used directly, but will be returned in the `lb` output map.
+DOC
 }
 
 variable "external_alb_ingress_cidrs" {

--- a/modules/elk-stack/main.tf
+++ b/modules/elk-stack/main.tf
@@ -53,13 +53,12 @@ module "elasticsearch" {
   name_prefix                 = "${var.name_prefix}"
   vpc_id                      = "${var.vpc_id}"
   key_name                    = "${var.ssh_key_name}"
-  public_subnet_ids           = ["${var.private_subnet_ids}"]
+  public_subnet_ids           = ["${var.public_subnet_ids}"]
   private_subnet_ids          = ["${var.private_subnet_ids}"]
   extra_sg_ids                = ["${aws_security_group.ssh.*.id}"]
   node_ami                    = "${coalesce(var.ami, module.ubuntu-ami.id)}"
   elasticsearch_version       = "${var.elk_version}"
   elasticsearch_dns_name      = "${var.elasticsearch_dns_name}"
-  elasticsearch_dns_ssl_name  = "${var.elasticsearch_dns_ssl_name}"
   data_node_count             = "${var.elasticsearch_data_node_count}"
   data_node_ebs_size          = "${var.elasticsearch_data_node_ebs_size}"
   data_node_snapshot_ids      = ["${var.elasticsearch_data_node_snapshot_ids}"]
@@ -88,11 +87,12 @@ module "kibana" {
   name_prefix               = "${var.name_prefix}"
   vpc_id                    = "${var.vpc_id}"
   kibana_version            = "${var.elk_version}"
+  public_subnet_ids         = ["${var.public_subnet_ids}"]
   private_subnet_ids        = ["${var.private_subnet_ids}"]
   key_name                  = ""
   ami                       = ""
   instance_type             = ""
-  elasticsearch_url         = "http://${var.elasticsearch_internal_alb["dns_name"]}:9200"
+  elasticsearch_url         = "http://${module.elasticsearch.internal_lb["dns_name"]}:9200"
   min_server_count          = 0
   max_server_count          = 0
   desired_server_count      = 0
@@ -104,31 +104,29 @@ module "kibana" {
 module "logstash-kibana" {
   source = "../logstash"
 
-  name_prefix             = "${var.name_prefix}"
-  name_suffix             = "-kibana"
-  vpc_id                  = "${var.vpc_id}"
-  public_subnet_ids       = ["${var.public_subnet_ids}"]
-  private_subnet_ids      = ["${var.private_subnet_ids}"]
-  logstash_version        = "${var.elk_version}"
-  logstash_dns_name       = "${var.logstash_dns_name}"
-  ami                     = "${coalesce(var.ami, module.ubuntu-ami.id)}"
-  instance_type           = "${var.logstash_kibana_instance_type}"
-  key_name                = "${var.ssh_key_name}"
-  elasticsearch_url       = "http://${var.elasticsearch_internal_alb["dns_name"]}:9200"
-  min_server_count        = "${var.logstash_kibana_min_server_count}"
-  max_server_count        = "${var.logstash_kibana_max_server_count}"
-  desired_server_count    = "${var.logstash_kibana_desired_server_count}"
-  extra_sg_ids            = [
+  name_prefix                 = "${var.name_prefix}"
+  name_suffix                 = "-kibana"
+  vpc_id                      = "${var.vpc_id}"
+  public_subnet_ids           = ["${var.public_subnet_ids}"]
+  private_subnet_ids          = ["${var.private_subnet_ids}"]
+  logstash_version            = "${var.elk_version}"
+  logstash_dns_name           = "${var.logstash_dns_name}"
+  ami                         = "${coalesce(var.ami, module.ubuntu-ami.id)}"
+  instance_type               = "${var.logstash_kibana_instance_type}"
+  key_name                    = "${var.ssh_key_name}"
+  elasticsearch_url           = "http://${module.elasticsearch.internal_lb["dns_name"]}:9200"
+  min_server_count            = "${var.logstash_kibana_min_server_count}"
+  max_server_count            = "${var.logstash_kibana_max_server_count}"
+  desired_server_count        = "${var.logstash_kibana_desired_server_count}"
+  extra_sg_ids                = [
     "${module.kibana.security_group_id}",
-    "${aws_security_group.ssh.*.id}"
+    "${aws_security_group.ssh.*.id}",
+    "${module.kibana.lb["security_group_id"]}"
   ]
-  extra_setup_snippet     = "${module.kibana.setup_snippet}"
-  extra_elb_ingress_cidrs = ["${concat(list(data.aws_vpc.current.cidr_block), var.logstash_extra_ingress_cidrs)}"]
-  target_group_arns       = [
-    "${module.kibana.http_target_group_arn}",
-    "${module.kibana.https_target_group_arn}",
-  ]
-
+  extra_setup_snippet         = "${module.kibana.setup_snippet}"
+  extra_elb_ingress_cidrs     = ["${concat(list(data.aws_vpc.current.cidr_block), var.logstash_extra_ingress_cidrs)}"]
+  elb_names                   = ["${module.kibana.elb_name}"]
+  target_group_arns           = "${compact(list(module.kibana.http_target_group_arn, module.kibana.https_target_group_arn))}"
   certstrap_depot_path        = "${var.certstrap_depot_path}"
   certstrap_ca_common_name    = "${var.certstrap_ca_common_name}"
   certstrap_ca_passphrase     = "${var.certstrap_ca_passphrase}"

--- a/modules/elk-stack/output.tf
+++ b/modules/elk-stack/output.tf
@@ -24,6 +24,18 @@ output "elasticsearch_data_node_ebs_volume_ids" {
   value = ["${module.elasticsearch.data_node_ebs_volume_ids}"]
 }
 
+output "elasticsearch_internal_lb" {
+  value = "${module.elasticsearch.internal_lb}"
+}
+
+output "elasticsearch_external_lb" {
+  value = "${module.elasticsearch.external_lb}"
+}
+
+output "kibana_lb" {
+  value = "${module.kibana.lb}"
+}
+
 output "logstash_kibana_asg_name" {
   value = "${module.logstash-kibana.asg_name}"
 }

--- a/modules/elk-stack/variables.tf
+++ b/modules/elk-stack/variables.tf
@@ -36,11 +36,6 @@ variable "elasticsearch_dns_name" {
   description = "DNS name for Elasticsearch"
 }
 
-variable "elasticsearch_dns_ssl_name" {
-  default     = ""
-  description = "DNS name for Elasticsearch endpoint SSL. An SSL certificate is expected to be present in ACM for this domain. If left empty 'elasticsearch_dns_name' will be checked instead."
-}
-
 variable "elasticsearch_master_node_count" {
   description = "Number of master nodes in the cluster. It should be either 1, 3 or more, in order to deal with split brain"
   default     = 1

--- a/modules/elk-stack/variables.tf
+++ b/modules/elk-stack/variables.tf
@@ -98,13 +98,13 @@ variable "elasticsearch_extra_config" {
 
 variable "elasticsearch_internal_alb" {
   type        = "map"
-  description = "Internal ALB information for Elasticsearch API"
+  description = "Internal ALB information for Elasticsearch API. See `elasticsearch.internal_alb` variable for more info."
 }
 
 variable "elasticsearch_external_alb" {
   type        = "map"
   default     = {}
-  description = "External ALB information for Elasticsearch API secured with BasicAuth"
+  description = "External ALB information for Elasticsearch API secured with BasicAuth.  See `elasticsearch.external_alb` variable for more info."
 }
 
 variable "elasticsearch_external_alb_setup" {
@@ -148,7 +148,7 @@ variable "logstash_dns_name" {
 
 variable "kibana_alb" {
   type        = "map"
-  description = "ALB information for Kibana"
+  description = "ALB information for Kibana. See `kibana.alb` variable for more info."
 }
 
 variable "certstrap_depot_path" {

--- a/modules/kibana/main.tf
+++ b/modules/kibana/main.tf
@@ -14,6 +14,7 @@ data "aws_subnet" "private" {
 
 
 resource "aws_alb_target_group" "kibana-https" {
+  count    = "${lookup(var.alb, "deploy_elb", false) ? 0 : 1}"
   name     = "${var.name_prefix}-kibana-https"
   port     = 5602
   protocol = "HTTP"
@@ -37,6 +38,7 @@ resource "aws_alb_target_group" "kibana-https" {
 
 // Target group for redirect to https
 resource "aws_alb_target_group" "kibana-http" {
+  count    = "${lookup(var.alb, "deploy_elb", false) ? 0 : 1}"
   name     = "${var.name_prefix}-kibana-http"
   port     = 80
   protocol = "HTTP"
@@ -130,5 +132,45 @@ USER_DATA
 
   lifecycle = {
     create_before_destroy = true
+  }
+}
+
+resource "aws_elb" "kibana-elb" {
+  count           = "${lookup(var.alb, "deploy_elb", false) ? 1 : 0}"
+  name            = "${var.name_prefix}-kibana"
+  subnets         = ["${var.public_subnet_ids}"]
+  security_groups = ["${var.alb["security_group_id"]}"]
+  internal        = "${lookup(var.alb, "deploy_elb_internal", true)}"
+
+  listener {
+    instance_port      = 5602
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${var.alb["certificate"]}"
+  }
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
+  # health_check {
+  #   healthy_threshold = 2
+  #   unhealthy_threshold = 5
+  #   timeout = 10
+  #   target = "HTTP:5603/"
+  #   interval = 60
+  # }
+
+  cross_zone_load_balancing   = "${lookup(var.alb, "deploy_elb_cross_zone", true)}"
+  idle_timeout                = 60
+  connection_draining         = true
+  connection_draining_timeout = 60
+
+  tags {
+    Name = "${var.name_prefix}-kibana-elb"
   }
 }

--- a/modules/kibana/main.tf
+++ b/modules/kibana/main.tf
@@ -147,7 +147,7 @@ resource "aws_elb" "kibana-elb" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${var.alb["certificate"]}"
+    ssl_certificate_id = "${var.alb["certificate_arn"]}"
   }
 
   listener {

--- a/modules/kibana/outputs.tf
+++ b/modules/kibana/outputs.tf
@@ -14,9 +14,23 @@ output "asg_name" {
 }
 
 output "http_target_group_arn" {
-  value = "${aws_alb_target_group.kibana-http.arn}"
+  value = "${element(coalescelist(aws_alb_target_group.kibana-http.*.arn, list("")), 0)}"
 }
 
 output "https_target_group_arn" {
-  value = "${aws_alb_target_group.kibana-https.arn}"
+  value = "${element(coalescelist(aws_alb_target_group.kibana-https.*.arn, list("")), 0)}"
+}
+
+
+//  ELB related info. Will either be ELB or ALB info.
+output "lb" {
+  value = {
+    "dns_name"          = "${element(coalescelist(aws_elb.kibana-elb.*.dns_name, list(lookup(var.alb, "dns_name", ""))), 0)}"
+    "zone_id"           = "${element(coalescelist(aws_elb.kibana-elb.*.zone_id, list(lookup(var.alb, "zone_id", ""))), 0)}"
+    "security_group_id" = "${var.alb["security_group_id"]}"
+  }
+}
+
+output "elb_name" {
+  value = "${aws_elb.kibana-elb.*.name}"
 }

--- a/modules/kibana/variables.tf
+++ b/modules/kibana/variables.tf
@@ -57,20 +57,24 @@ variable "credstash_get_cmd" {
   description = "Credstash get command with region and table values set."
 }
 
-/**
- Argument is expected to have this structure:
-  * security_group_id (required)
-  * certificate (required) - ARN of ACM certificate to be used.
-  * deploy_elb (optional, default: false) - if set to true ELB will be deployed.
-  * deploy_elb_internal (optional, default: true) - if set to false ELB will be deployed as an external one.
-  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ for ELB will be off.
-  Below are only required if `deploy_elb` is set to `false` or ommited.
-  * arn - ALB ARN
-  * dns_name - host-header for ALB listener rule
-*/
 variable "alb" {
   type        = "map"
-  description = "Information about ALB"
+  description = <<DOC
+Information on already existing Application LB or settings for a Classic LB to
+be deployed:
+  * certificate_arn (required) - ARN of ACM certificate to be used.
+  * security_group_id (required)
+  * deploy_elb (optional, default: false) - if set to true ELB will be deployed
+    and used instead of an ALB.
+  * deploy_elb_internal (optional, default: true) - if set to false ELB will be
+    deployed as an external one.
+  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ
+    for ELB will be off.
+Below are only required if `deploy_elb` is set to `false` or omitted:
+  * arn - ALB ARN.
+  * dns_name - host-header for ALB listener rule.
+  * zone_id - not used directly, but will be returned in the `lb` output map.
+DOC
 }
 
 variable "kibana_version" {

--- a/modules/kibana/variables.tf
+++ b/modules/kibana/variables.tf
@@ -30,6 +30,12 @@ variable "private_subnet_ids" {
   type        = "list"
 }
 
+variable "public_subnet_ids" {
+  description = "A list of public subnet ids to deploy ELB in. Unused when separately deployed AALB is being used."
+  default     = []
+  type        = "list"
+}
+
 variable "elasticsearch_url" {
   description = "Elasticsearch endpoint URL"
 }
@@ -51,6 +57,17 @@ variable "credstash_get_cmd" {
   description = "Credstash get command with region and table values set."
 }
 
+/**
+ Argument is expected to have this structure:
+  * security_group_id (required)
+  * certificate (required) - ARN of ACM certificate to be used.
+  * deploy_elb (optional, default: false) - if set to true ELB will be deployed.
+  * deploy_elb_internal (optional, default: true) - if set to false ELB will be deployed as an external one.
+  * deploy_elb_cross_zone (optional, default: true) - if set to false cross AZ for ELB will be off.
+  Below are only required if `deploy_elb` is set to `false` or ommited.
+  * arn - ALB ARN
+  * dns_name - host-header for ALB listener rule
+*/
 variable "alb" {
   type        = "map"
   description = "Information about ALB"

--- a/modules/logstash/main.tf
+++ b/modules/logstash/main.tf
@@ -146,7 +146,7 @@ resource "aws_autoscaling_group" "logstash-asg" {
   launch_configuration      = "${aws_launch_configuration.logstash-lc.name}"
   health_check_type         = "ELB"
   health_check_grace_period = "600"
-  load_balancers            = ["${aws_elb.logstash-elb.name}"]
+  load_balancers            = ["${concat(list(aws_elb.logstash-elb.name), var.elb_names)}"]
   target_group_arns         = ["${var.target_group_arns}"]
 
   tag = [{

--- a/modules/logstash/variables.tf
+++ b/modules/logstash/variables.tf
@@ -132,6 +132,11 @@ variable "target_group_arns" {
   description = "Application Load Balancer target groups to be used for Logstash auto scaling group"
 }
 
+variable "elb_names" {
+  default     = []
+  description = "Extra ELBs that should be attached to ASG. Useful for attaching Kibana ELB."
+}
+
 variable "internal" {
   default     = true
   description = "Set it to false if you want Logstash to be accessible by the outside world"


### PR DESCRIPTION
* Using ALBs is still possible, but ELBs will be created as an option.
* Extracted away ACM certificates lookup, those are now expected as a variable
  to external LBs.
* Elasticsearch is now properly deployed in private subnets, while external
  LB is in public

Here is an example difference of how to use ELB vs ALB for Elasticsearch (variable to `elk-stack` module):
```hcl
  elasticsearch_internal_alb              = {
    "arn"               = "${aws_alb.es-internal.arn}"
    "dns_name"          = "${aws_alb.es-internal.dns_name}"
    "zone_id"           = "${aws_alb.es-internal.zone_id}"
    "security_group_id" = "${aws_security_group.es-internal-alb.id}"
  }
```
So, in order to deploy ELB, all that is necessary is `deploy_elb`:
```hcl
  elasticsearch_internal_alb              = {
    "deploy_elb"        = true
    "security_group_id" = "${aws_security_group.es-internal-alb.id}"
  }
```

Few extra arguments are also available in that map:
  * `security_group_id` (required)
  * `certificate` (required) - ARN of ACM certificate to be used.
  * `deploy_elb` (optional, default: false) - if set to true ELB will be deployed.
  * `deploy_elb_internal` (optional, default: true) - if set to false ELB will be deployed as an external one.
  * `deploy_elb_cross_zone` (optional, default: true) - if set to false cross AZ for ELB will be off.

Below are only required if `deploy_elb` is set to `false` or omitted:
  * `arn` - ALB ARN
  * `dns_name` - host-header for ALB listener rule

Same approach goes for all three places where ALB/ELB is used:
* Elasticsearch internal API (for unauthenticated requests from logstash running in the same VPC)
* Elasticsearch external API with BasicAuth
* Publicly accessible Kibana with BasicAuth.