### PR TITLE
Moved the hardcoded coreos ami_id to a variable from kube public and private stack

### DIFF
--- a/examples/kube-stack-private/kube.tf
+++ b/examples/kube-stack-private/kube.tf
@@ -24,9 +24,9 @@ module "kube-cluster" {
     "${module.kube-load-balancer-sg.id}",
   ]
 
-  controller_ami        = "ami-3f061b45"
+  controller_ami        = "${var.coreos_stable_ami}"
   controller_subnet_ids = ["${module.vpc.private_subnet_ids}"]
-  worker_ami            = "ami-3f061b45"
+  worker_ami            = "${var.coreos_stable_ami}"
   worker_subnet_ids     = ["${module.vpc.private_subnet_ids}"]
 
   controller_security_group_ids = [

--- a/examples/kube-stack-private/variables.tf
+++ b/examples/kube-stack-private/variables.tf
@@ -17,6 +17,11 @@ variable "instance_type" {
   description = "map of instance types to use"
 }
 
+variable "coreos_stable_ami_id" {
+  description = "set a stable coreos ami id"
+  # for a different regions, change to https://goo.gl/2vJs7F
+}
+
 #variable "kube_cluster_name" {
 #  description = "name of the kube cluster deployed to the VPC, used to tag resources"
 #}

--- a/examples/kube-stack-public/kube.tf
+++ b/examples/kube-stack-public/kube.tf
@@ -26,9 +26,9 @@ module "kube-cluster" {
     "${aws_security_group.open-egress.id}",
   ]
 
-  controller_ami        = "ami-d88605b9"
+  controller_ami        = "${var.coreos_stable_ami_id}"
   controller_subnet_ids = ["${module.vpc.public_subnet_ids}"]
-  worker_ami            = "ami-d88605b9"
+  worker_ami            = "${var.coreos_stable_ami_id}"
   worker_subnet_ids     = ["${module.vpc.public_subnet_ids}"]
 
   controller_security_group_ids = [

--- a/examples/kube-stack-public/variables.tf
+++ b/examples/kube-stack-public/variables.tf
@@ -17,6 +17,11 @@ variable "instance_type" {
   description = "map of instance types to use"
 }
 
+variable "coreos_stable_ami_id" {
+  description = "set a stable coreos ami id"
+  # for a different regions, change to https://goo.gl/2vJs7F
+}
+
 #variable "kube_cluster_name" {
 #  description = "name of the kube cluster deployed to the VPC, used to tag resources"
 #}


### PR DESCRIPTION
The `ami_id` changes according to the region of Amazon, this PR moved the hardcoded CoreOS ami_id to a variable.