### PR TITLE
Fix typo `coreos_stable_ami_id` variable name and update CoreOS AMI link

### DIFF
--- a/examples/kube-stack-private/kube.tf
+++ b/examples/kube-stack-private/kube.tf
@@ -24,9 +24,9 @@ module "kube-cluster" {
     "${module.kube-load-balancer-sg.id}",
   ]
 
-  controller_ami        = "${var.coreos_stable_ami}"
+  controller_ami        = "${var.coreos_stable_ami_id}"
   controller_subnet_ids = ["${module.vpc.private_subnet_ids}"]
-  worker_ami            = "${var.coreos_stable_ami}"
+  worker_ami            = "${var.coreos_stable_ami_id}"
   worker_subnet_ids     = ["${module.vpc.private_subnet_ids}"]
 
   controller_security_group_ids = [

--- a/examples/kube-stack-private/variables.tf
+++ b/examples/kube-stack-private/variables.tf
@@ -18,8 +18,8 @@ variable "instance_type" {
 }
 
 variable "coreos_stable_ami_id" {
-  description = "set a stable coreos ami id"
-  # for a different regions, change to https://goo.gl/2vJs7F
+  description = "set a stable coreos ami id from https://goo.gl/wLhUyH"
+  # for a different regions, change to https://goo.gl/wLhUyH
 }
 
 #variable "kube_cluster_name" {

--- a/examples/kube-stack-public/variables.tf
+++ b/examples/kube-stack-public/variables.tf
@@ -18,8 +18,8 @@ variable "instance_type" {
 }
 
 variable "coreos_stable_ami_id" {
-  description = "set a stable coreos ami id"
-  # for a different regions, change to https://goo.gl/2vJs7F
+  description = "set a stable coreos ami id from https://goo.gl/wLhUyH"
+  # for a different regions, change to https://goo.gl/wLhUyH
 }
 
 #variable "kube_cluster_name" {


### PR DESCRIPTION
Fix typo for `coreos_stable_ami_id` variable name and update CoreOS AMI link