### PR TITLE
Add Kube Controller, Worker, and Load Balancer security groups modules

### DIFF
--- a/examples/kube-stack-private/kube.tf
+++ b/examples/kube-stack-private/kube.tf
@@ -38,76 +38,20 @@ module "kube-cluster" {
   ]
 }
 
-# security group for kube controller
 module "kube-controller-sg" {
-  source      = "../../modules/security-group-base"
+  source      = "../../modules/kube-controller-sg"
   name        = "${var.name}-kube-controller"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube controllers in ${var.name}"
+  cidr_blocks = "${var.vpc_cidr}"
 }
 
-module "kube-controller-private-ssh-rule" {
-  source            = "../../modules/ssh-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-kube-api-rule" {
-  source            = "../../modules/single-port-sg"
-  port              = "6443"
-  protocol          = "tcp"
-  description       = "Allow access to kube api from hosts in ${var.name} VPC"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-etcd-rule" {
-  source            = "../../modules/etcd-server-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-# security group for kube worker
 module "kube-worker-sg" {
-  source      = "../../modules/security-group-base"
+  source      = "../../modules/kube-worker-sg"
   name        = "${var.name}-kube-worker"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube workers in ${var.name}"
+  cidr_blocks = "${var.vpc_cidr}"
 }
 
-# allow ingress on any port, to kube workers, from any host in the VPC
-module "kube-worker-open-ingress-rule" {
-  source            = "../../modules/open-ingress-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-worker-sg.id}"
-}
-
-module "kube-worker-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-worker-sg.id}"
-}
-# security group for load balancer
-module "kube-load-balancer-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-load-balancer"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube load-balancer in ${var.name}"
-}
-
-module "kube-load-balancer-api-rule" {
-  source            = "../../modules/single-port-sg"
-  port              = "443"
-  description       = "Public ingress to ELB for Kubernetes API controller, port 443"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${module.kube-load-balancer-sg.id}"
-}
-
-module "kube-load-balancer-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-load-balancer-sg.id}"
+module "kube-loadbalancer-sg" {
+  source      = "../../modules/kube-loadbalancer-sg"
+  name        = "${var.name}-kube-loadbalancer"
+  cidr_blocks = "${var.vpc_cidr}"
 }

--- a/examples/kube-stack-private/kube.tf
+++ b/examples/kube-stack-private/kube.tf
@@ -21,7 +21,7 @@ module "kube-cluster" {
   controller_iam_profile = "${module.kube-controller-iam.aws_iam_instance_profile_name}"
 
   lb_security_group_ids = [
-    "${module.kube-load-balancer-sg.id}",
+    "${module.sg-lb.id}",
   ]
 
   controller_ami        = "${var.coreos_stable_ami_id}"
@@ -39,19 +39,29 @@ module "kube-cluster" {
 }
 
 module "kube-controller-sg" {
-  source      = "../../modules/kube-controller-sg"
-  name        = "${var.name}-kube-controller"
-  cidr_blocks = "${var.vpc_cidr}"
+  source                    = "../../modules/kube-controller-sg"
+  name_prefix               = "${var.name}"
+  name_suffix               = "kube-controller"
+  vpc_id                    = "${module.vpc.vpc_id}"
+  vpc_cidr                  = "${var.vpc_cidr}"
+  vpc_cidr_controller_api   = "${var.vpc_cidr}"
+  vpc_cidr_controller_ssh   = "${var.vpc_cidr_controller_ssh}"
+  vpc_cidr_controller_etcd  = "${var.vpc_cidr_controller_etcd}"
 }
 
 module "kube-worker-sg" {
-  source      = "../../modules/kube-worker-sg"
-  name        = "${var.name}-kube-worker"
-  cidr_blocks = "${var.vpc_cidr}"
+  source                = "../../modules/kube-worker-sg"
+  name_prefix           = "${var.name}"
+  name_suffix           = "kube-worker"
+  vpc_id                = "${module.vpc.vpc_id}"
+  vpc_cidr              = "${var.vpc_cidr}"
+  vpc_cidr_worker_ssh   = "${var.vpc_cidr_worker_ssh}"
 }
 
-module "kube-loadbalancer-sg" {
+module "sg-lb" {
   source      = "../../modules/kube-loadbalancer-sg"
-  name        = "${var.name}-kube-loadbalancer"
-  cidr_blocks = "${var.vpc_cidr}"
+  name_prefix = "${var.name}"
+  name_suffix = "kube-loadbalancer"
+  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_cidr    = "${var.vpc_cidr}"
 }

--- a/examples/kube-stack-private/variables.tf
+++ b/examples/kube-stack-private/variables.tf
@@ -1,5 +1,5 @@
 variable "region" {
-  default     = "us-west-2"
+  default     = "us-west-1"
   description = "AWS region this env is deployed to"
 }
 
@@ -19,6 +19,7 @@ variable "instance_type" {
 
 variable "coreos_stable_ami_id" {
   description = "set a stable coreos ami id from https://goo.gl/wLhUyH"
+  default = "ami-cc0900ac"
   # for a different regions, change to https://goo.gl/wLhUyH
 }
 
@@ -40,6 +41,26 @@ variable "ssh_key" {
 
 variable "vpc_cidr" {
   description = "Top-level CIDR for the whole VPC network space"
+  default     = "10.10.0.0/16"
+}
+
+variable "vpc_cidr_controller_api" {
+  description = "Top-level CIDR for kube api access"
+  default     = "10.10.0.0/16"
+}
+
+variable "vpc_cidr_controller_ssh" {
+  description = "Top-level CIDR for ssh access"
+  default     = "10.10.0.0/16"
+}
+
+variable "vpc_cidr_controller_etcd" {
+  description = "Top-level CIDR for etcd"
+  default     = "10.10.0.0/16"
+}
+
+variable "vpc_cidr_worker_ssh" {
+  description = "top-level cidr for the whole vpc network space"
   default     = "10.10.0.0/16"
 }
 

--- a/modules/kube-controller-sg/README.md
+++ b/modules/kube-controller-sg/README.md
@@ -1,3 +1,17 @@
 ## Kube Controller Security Group
 
 Define a security group for kube controller
+provisioning for kube controller sg example:
+
+```
+module "kube-controller-sg" {
+ source                    = "../../modules/kube-controller-sg"
+ name_prefix               = "${var.name}"
+ name_suffix               = "kube-controller"
+ vpc_id                    = "${module.vpc.vpc_id}"
+ vpc_cidr                  = "${var.vpc_cidr}"
+ vpc_cidr_controller_api   = "${var.vpc_cidr_controller_api}"
+ vpc_cidr_controller_ssh   = "${var.vpc_cidr_controller_ssh}"
+ vpc_cidr_controller_etcd  = "${var.vpc_cidr_controller_etcd}"
+}
+```

--- a/modules/kube-controller-sg/README.md
+++ b/modules/kube-controller-sg/README.md
@@ -1,0 +1,3 @@
+## Kube Controller Security Group
+
+Define a security group for kube controller

--- a/modules/kube-controller-sg/main.tf
+++ b/modules/kube-controller-sg/main.tf
@@ -3,46 +3,49 @@
  *
  * Define a security group for kube controller
  *
+ * provisioning for kube controller sg example:
+ * module "kube-controller-sg" {
+ *  source                    = "../../modules/kube-controller-sg"
+ *  name_prefix               = "${var.name}"
+ *  name_suffix               = "kube-controller"
+ *  vpc_id                    = "${module.vpc.vpc_id}"
+ *  vpc_cidr                  = "${var.vpc_cidr}"
+ *  vpc_cidr_controller_api   = "${var.vpc_cidr_controller_api}"
+ *  vpc_cidr_controller_ssh   = "${var.vpc_cidr_controller_ssh}"
+ *  vpc_cidr_controller_etcd  = "${var.vpc_cidr_controller_etcd}"
+ * }
+ *
  */
-
-variable "cidr_blocks" {
-  description = "List of CIDR block ranges that the SG allows ingress from"
-  type        = "list"
-}
-
-variable "name" {
-  description = "Name of the Kube Controller security group"
-}
 
 module "kube-controller-sg" {
   source      = "../security-group-base"
-  name        = "${var.name}"
-  vpc_id      = "${module.vpc.vpc_id}"
+  name        = "${var.name_prefix}-${var.name_suffix}"
+  vpc_id      = "${var.vpc_id}"
   description = "Security group for the kube controllers in ${var.name}"
 }
 
-module "kube-controller-private-ssh-rule" {
-  source            = "../ssh-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-kube-api-rule" {
+module "api-rule" {
   source            = "../single-port-sg"
   port              = "6443"
   protocol          = "tcp"
   description       = "Allow access to kube api from hosts in ${var.name} VPC"
-  cidr_blocks       = ["${var.vpc_cidr}"]
+  cidr_blocks       = ["${var.vpc_cidr_controller_api}"]
   security_group_id = "${module.kube-controller-sg.id}"
 }
 
-module "kube-controller-etcd-rule" {
+module "private-ssh-rule" {
+  source            = "../ssh-sg"
+  cidr_blocks       = ["${var.vpc_cidr_controller_ssh}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "etcd-rule" {
   source            = "../etcd-server-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
+  cidr_blocks       = ["${var.vpc_cidr_controller_etcd}"]
   security_group_id = "${module.kube-controller-sg.id}"
 }
 
-module "kube-controller-open-egress-rule" {
+module "open-egress-rule" {
   source            = "../open-egress-sg"
   security_group_id = "${module.kube-controller-sg.id}"
 }

--- a/modules/kube-controller-sg/main.tf
+++ b/modules/kube-controller-sg/main.tf
@@ -1,0 +1,48 @@
+/**
+ * ## Kube Controller Security Group
+ *
+ * Define a security group for kube controller
+ *
+ */
+
+variable "cidr_blocks" {
+  description = "List of CIDR block ranges that the SG allows ingress from"
+  type        = "list"
+}
+
+variable "name" {
+  description = "Name of the Kube Controller security group"
+}
+
+module "kube-controller-sg" {
+  source      = "../security-group-base"
+  name        = "${var.name}"
+  vpc_id      = "${module.vpc.vpc_id}"
+  description = "Security group for the kube controllers in ${var.name}"
+}
+
+module "kube-controller-private-ssh-rule" {
+  source            = "../ssh-sg"
+  cidr_blocks       = ["${var.vpc_cidr}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "kube-controller-kube-api-rule" {
+  source            = "../single-port-sg"
+  port              = "6443"
+  protocol          = "tcp"
+  description       = "Allow access to kube api from hosts in ${var.name} VPC"
+  cidr_blocks       = ["${var.vpc_cidr}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "kube-controller-etcd-rule" {
+  source            = "../etcd-server-sg"
+  cidr_blocks       = ["${var.vpc_cidr}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "kube-controller-open-egress-rule" {
+  source            = "../open-egress-sg"
+  security_group_id = "${module.kube-controller-sg.id}"
+}

--- a/modules/kube-controller-sg/output.tf
+++ b/modules/kube-controller-sg/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+ value = "${module.kube-controller-sg.id}"
+}

--- a/modules/kube-controller-sg/variables.tf
+++ b/modules/kube-controller-sg/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "Name of this deployment, the VPC and all resources therein"
+  default     = "kube-stack-test"
+}
+
+variable "name_suffix" {
+  description = "suffix to include when naming the various resources"
+}
+
+variable "name_prefix" {
+  description = "Prefix that will be added to names of all resources"
+}
+
+variable "vpc_id" {
+  description = "VPC id where Elasticsearch cluster is deployed"
+}
+
+variable "vpc_cidr" {
+  description = "Top-level CIDR for the whole VPC network space"
+}
+
+variable "vpc_cidr_controller_api" {
+  description = "Top-level CIDR for kube api access"
+}
+
+variable "vpc_cidr_controller_ssh" {
+  description = "Top-level CIDR for ssh access"
+}
+
+variable "vpc_cidr_controller_etcd" {
+  description = "Top-level CIDR for etcd"
+}

--- a/modules/kube-loadbalancer-sg/README.md
+++ b/modules/kube-loadbalancer-sg/README.md
@@ -1,0 +1,3 @@
+## Kube Load Balancer Security Group
+
+Define a security group for kube load balancer

--- a/modules/kube-loadbalancer-sg/README.md
+++ b/modules/kube-loadbalancer-sg/README.md
@@ -1,3 +1,13 @@
 ## Kube Load Balancer Security Group
 
 Define a security group for kube load balancer
+provisioning Kube Load Balancer example:
+```
+module "sg-lb" {
+  source      = "../../modules/kube-loadbalancer-sg"
+  name_prefix = "${var.name}"
+  name_suffix = "kube-loadbalancer"
+  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_cidr    = "${var.vpc_cidr}"
+}
+```

--- a/modules/kube-loadbalancer-sg/main.tf
+++ b/modules/kube-loadbalancer-sg/main.tf
@@ -3,24 +3,33 @@
  *
  * Define a security group for kube load balancer
  *
+ * provisioning Kube Load Balancer example:
+ * module "sg-lb" {
+ *   source      = "../../modules/kube-loadbalancer-sg"
+ *   name_prefix = "${var.name}"
+ *   name_suffix = "kube-loadbalancer"
+ *   vpc_id      = "${module.vpc.vpc_id}"
+ *   vpc_cidr    = "${var.vpc_cidr}"
+ * }
+ *
  */
 
-module "kube-load-balancer-sg" {
+module "sg-lb" {
   source      = "../security-group-base"
-  name        = "${var.name}"
-  vpc_id      = "${module.vpc.vpc_id}"
+  name        = "${var.name_prefix}-${var.name_suffix}"
+  vpc_id      = "${var.vpc_id}"
   description = "Security group for the kube load-balancer in ${var.name}"
 }
 
-module "kube-load-balancer-api-rule" {
+module "api-rule" {
   source            = "../single-port-sg"
   port              = "443"
   description       = "Public ingress to ELB for Kubernetes API controller, port 443"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${module.kube-load-balancer-sg.id}"
+  security_group_id = "${module.sg-lb.id}"
 }
 
-module "kube-load-balancer-open-egress-rule" {
+module "open-egress-rule" {
   source            = "../open-egress-sg"
-  security_group_id = "${module.kube-load-balancer-sg.id}"
+  security_group_id = "${module.sg-lb.id}"
 }

--- a/modules/kube-loadbalancer-sg/main.tf
+++ b/modules/kube-loadbalancer-sg/main.tf
@@ -1,0 +1,26 @@
+/**
+ * ## Kube Load Balancer Security Group
+ *
+ * Define a security group for kube load balancer
+ *
+ */
+
+module "kube-load-balancer-sg" {
+  source      = "../security-group-base"
+  name        = "${var.name}"
+  vpc_id      = "${module.vpc.vpc_id}"
+  description = "Security group for the kube load-balancer in ${var.name}"
+}
+
+module "kube-load-balancer-api-rule" {
+  source            = "../single-port-sg"
+  port              = "443"
+  description       = "Public ingress to ELB for Kubernetes API controller, port 443"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.kube-load-balancer-sg.id}"
+}
+
+module "kube-load-balancer-open-egress-rule" {
+  source            = "../open-egress-sg"
+  security_group_id = "${module.kube-load-balancer-sg.id}"
+}

--- a/modules/kube-loadbalancer-sg/output.tf
+++ b/modules/kube-loadbalancer-sg/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+ value = "${module.sg-lb.id}"
+}

--- a/modules/kube-loadbalancer-sg/variables.tf
+++ b/modules/kube-loadbalancer-sg/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Name of the Kube Controller security group"
+  default     = "kube-stack-test"
+}
+
+variable "name_suffix" {
+  description = "suffix to include when naming the various resources"
+}
+
+variable "name_prefix" {
+  description = "Prefix that will be added to names of all resources"
+}
+
+variable "vpc_id" {
+  description = "VPC id where Elasticsearch cluster is deployed"
+}
+
+variable "vpc_cidr" {
+  description = "Top-level CIDR for the whole VPC network space"
+}

--- a/modules/kube-worker-sg/README.md
+++ b/modules/kube-worker-sg/README.md
@@ -2,4 +2,14 @@
 
 Define a security group for kube worker
 
-
+provisioning Kube worker sg example:
+```
+module "kube-worker-sg" {
+  source                = "../../modules/kube-worker-sg"
+  name_prefix           = "${var.name}"
+  name_suffix           = "kube-worker"
+  vpc_id                = "${module.vpc.vpc_id}"
+  vpc_cidr              = "${var.vpc_cidr}"
+  vpc_cidr_worker_ssh   = "${var.vpc_cidr_worker_ssh}"
+}
+```

--- a/modules/kube-worker-sg/README.md
+++ b/modules/kube-worker-sg/README.md
@@ -1,0 +1,5 @@
+## Kube Worker Security Group
+
+Define a security group for kube worker
+
+

--- a/modules/kube-worker-sg/main.tf
+++ b/modules/kube-worker-sg/main.tf
@@ -1,0 +1,35 @@
+/**
+ * ## Kube Worker Security Group
+ *
+ * Define a security group for kube worker
+ *
+ */
+
+variable "cidr_blocks" {
+  description = "List of CIDR block ranges that the SG allows ingress from"
+  type        = "list"
+}
+
+variable "name" {
+  description = "Name of the Kube Controller security group"
+}
+
+# security group for kube worker
+module "kube-worker-sg" {
+  source      = "../security-group-base"
+  name        = "${var.name}-kube-worker"
+  vpc_id      = "${module.vpc.vpc_id}"
+  description = "Security group for the kube workers in ${var.name}"
+}
+
+# allow ingress on any port, to kube workers, from any host in the VPC
+module "kube-worker-open-ingress-rule" {
+  source            = "../open-ingress-sg"
+  cidr_blocks       = ["${var.vpc_cidr}"]
+  security_group_id = "${module.kube-worker-sg.id}"
+}
+
+module "kube-worker-open-egress-rule" {
+  source            = "../open-egress-sg"
+  security_group_id = "${module.kube-worker-sg.id}"
+}

--- a/modules/kube-worker-sg/output.tf
+++ b/modules/kube-worker-sg/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+ value = "${module.kube-worker-sg.id}"
+}

--- a/modules/kube-worker-sg/variables.tf
+++ b/modules/kube-worker-sg/variables.tf
@@ -1,0 +1,23 @@
+variable "name" {
+  description = "Name of the Kube Worker security group"
+  default     = "kube-stack-test"
+}
+
+variable "name_suffix" {
+  description = "suffix to include when naming the various resources"
+}
+
+variable "name_prefix" {
+  description = "Prefix that will be added to names of all resources"
+}
+
+variable "vpc_id" {
+  description = "VPC id where Elasticsearch cluster is deployed"
+}
+variable "vpc_cidr" {
+  description = "Top-level CIDR for the whole VPC network space"
+}
+
+variable "vpc_cidr_worker_ssh" {
+  description = "Top-level CIDR for ssh access"
+}


### PR DESCRIPTION
Add three new security group modules, one each for the Kube Controller, Worker, and Load Balancer.

- [x] Add the modules to Kube Stack Private 
- [x] Test running the plan and apply it