### PR TITLE
Create SG modules for Kubernetes clusters

### DIFF
--- a/examples/kube-stack-private/kube.tf
+++ b/examples/kube-stack-private/kube.tf
@@ -38,76 +38,30 @@ module "kube-cluster" {
   ]
 }
 
-# security group for kube controller
+# security group for kube controller nodes
 module "kube-controller-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-controller"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube controllers in ${var.name}"
+  source           = "../../modules/kube-controller-sg"
+  name_prefix      = "${var.name}"
+  vpc_id           = "${module.vpc.vpc_id}"
+  cidr_blocks_api  = ["${var.vpc_cidr}"]
+  cidr_blocks_ssh  = ["${var.vpc_cidr}"]
+  cidr_blocks_etcd = ["${var.vpc_cidr}"]
 }
 
-module "kube-controller-private-ssh-rule" {
-  source            = "../../modules/ssh-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-kube-api-rule" {
-  source            = "../../modules/single-port-sg"
-  port              = "6443"
-  protocol          = "tcp"
-  description       = "Allow access to kube api from hosts in ${var.name} VPC"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-etcd-rule" {
-  source            = "../../modules/etcd-server-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-# security group for kube worker
+# security group for kube worker nodes
 module "kube-worker-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-worker"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube workers in ${var.name}"
+  source          = "../../modules/kube-worker-sg"
+  name_prefix     = "${var.name}"
+  vpc_id          = "${module.vpc.vpc_id}"
+  cidr_blocks_ssh = ["${var.vpc_cidr}"]
+  # only allow open access to worker nodes in the VPC
+  cidr_blocks_open_ingress = ["${var.vpc_cidr}"]
 }
 
-# allow ingress on any port, to kube workers, from any host in the VPC
-module "kube-worker-open-ingress-rule" {
-  source            = "../../modules/open-ingress-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-worker-sg.id}"
-}
-
-module "kube-worker-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-worker-sg.id}"
-}
-# security group for load balancer
+# security group for kube load balancer (ELB)
 module "kube-load-balancer-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-load-balancer"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube load-balancer in ${var.name}"
-}
-
-module "kube-load-balancer-api-rule" {
-  source            = "../../modules/single-port-sg"
-  port              = "443"
-  description       = "Public ingress to ELB for Kubernetes API controller, port 443"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${module.kube-load-balancer-sg.id}"
-}
-
-module "kube-load-balancer-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-load-balancer-sg.id}"
+  source          = "../../modules/kube-load-balancer-sg"
+  name_prefix     = "${var.name}"
+  vpc_id          = "${module.vpc.vpc_id}"
+  cidr_blocks_api = ["${var.vpc_cidr}"]
 }

--- a/examples/kube-stack-public/kube.tf
+++ b/examples/kube-stack-public/kube.tf
@@ -39,77 +39,30 @@ module "kube-cluster" {
   ]
 }
 
-# security group for kube controller
+# security group for kube controller nodes
 module "kube-controller-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-controller"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube controllers in ${var.name}"
+  source           = "../../modules/kube-controller-sg"
+  name_prefix      = "${var.name}"
+  vpc_id           = "${module.vpc.vpc_id}"
+  cidr_blocks_api  = ["${var.vpc_cidr}"]
+  cidr_blocks_ssh  = ["${var.vpc_cidr}"]
+  cidr_blocks_etcd = ["${var.vpc_cidr}"]
 }
 
-module "kube-controller-private-ssh-rule" {
-  source            = "../../modules/ssh-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-kube-api-rule" {
-  source            = "../../modules/single-port-sg"
-  port              = "6443"
-  protocol          = "tcp"
-  description       = "Allow access to kube api from hosts in ${var.name} VPC"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-etcd-rule" {
-  source            = "../../modules/etcd-server-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-module "kube-controller-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-controller-sg.id}"
-}
-
-# security group for kube worker
+# security group for kube worker nodes
 module "kube-worker-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-worker"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube workers in ${var.name}"
+  source          = "../../modules/kube-worker-sg"
+  name_prefix     = "${var.name}"
+  vpc_id          = "${module.vpc.vpc_id}"
+  cidr_blocks_ssh = ["${var.vpc_cidr}"]
+  # allow ingress on any port, to kube workers, from any host in the VPC
+  cidr_blocks_open_ingress = ["${var.vpc_cidr}"]
 }
 
-# allow ingress on any port, to kube workers, from any host in the VPC
-module "kube-worker-open-ingress-rule" {
-  source            = "../../modules/open-ingress-sg"
-  cidr_blocks       = ["${var.vpc_cidr}"]
-  security_group_id = "${module.kube-worker-sg.id}"
-}
-
-module "kube-worker-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-worker-sg.id}"
-}
-
-# security group for load balancer
+# security group for kube ELB
 module "kube-load-balancer-sg" {
-  source      = "../../modules/security-group-base"
-  name        = "${var.name}-kube-load-balancer"
-  vpc_id      = "${module.vpc.vpc_id}"
-  description = "Security group for the kube load-balancer in ${var.name}"
-}
-
-module "kube-load-balancer-api-rule" {
-  source            = "../../modules/single-port-sg"
-  port              = "443"
-  description       = "Public ingress to ELB for Kubernetes API controller, port 443"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${module.kube-load-balancer-sg.id}"
-}
-
-module "kube-load-balancer-open-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${module.kube-load-balancer-sg.id}"
+  source          = "../../modules/kube-load-balancer-sg"
+  name_prefix     = "${var.name}"
+  vpc_id          = "${module.vpc.vpc_id}"
+  cidr_blocks_api = ["0.0.0.0/0"]
 }

--- a/modules/kube-controller-sg/README.md
+++ b/modules/kube-controller-sg/README.md
@@ -1,0 +1,24 @@
+## Kube Controller Security Group
+
+This module defines a security group for controller nodes in a kubernetes
+cluster. The module adds security group rules to allow access to the following:
+
+* the kube controller API
+* SSH on the kube controller nodes
+* etcd on the kube controller nodes
+* open egress for the controller nodes
+
+
+### How to use this module
+
+```terraform
+module "kube-controller-sg" {
+  source           = "fpco/foundation/aws//modules/kube-controller-sg"
+  version          = "..."
+  name_prefix      = "${var.name}"
+  vpc_id           = "${module.vpc.vpc_id}"
+  cidr_blocks_api  = ["${var.vpc_cidr}", "${var.corporate_net}"]
+  cidr_blocks_ssh  = ["${var.corporate_net}"]
+  cidr_blocks_etcd = ["${var.vpc_cidr}"]
+}
+```

--- a/modules/kube-controller-sg/main.tf
+++ b/modules/kube-controller-sg/main.tf
@@ -1,0 +1,32 @@
+module "kube-controller-sg" {
+  source      = "../security-group-base"
+  name        = "${var.name_prefix}-${var.name_suffix}"
+  vpc_id      = "${var.vpc_id}"
+  description = "Security group for the ${var.name_prefix} kube controller nodes"
+}
+
+module "api-rule" {
+  source            = "../single-port-sg"
+  port              = "${var.api_port}"
+  protocol          = "tcp"
+  description       = "Allow access to the kuberenets api"
+  cidr_blocks       = ["${var.cidr_blocks_api}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "private-ssh-rule" {
+  source            = "../ssh-sg"
+  cidr_blocks       = ["${var.cidr_blocks_ssh}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "etcd-rule" {
+  source            = "../etcd-server-sg"
+  cidr_blocks       = ["${var.cidr_blocks_etcd}"]
+  security_group_id = "${module.kube-controller-sg.id}"
+}
+
+module "open-egress-rule" {
+  source            = "../open-egress-sg"
+  security_group_id = "${module.kube-controller-sg.id}"
+}

--- a/modules/kube-controller-sg/output.tf
+++ b/modules/kube-controller-sg/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+ value = "${module.kube-controller-sg.id}"
+}

--- a/modules/kube-controller-sg/variables.tf
+++ b/modules/kube-controller-sg/variables.tf
@@ -1,0 +1,32 @@
+variable "name_prefix" {
+  description = "Prefix that will be added to names of all resources"
+}
+
+variable "name_suffix" {
+  description = "suffix to use when naming the various resources"
+  default     = "kube-controller"
+}
+
+variable "vpc_id" {
+  description = "VPC id for the security group"
+}
+
+variable "api_port" {
+  description = "TCP port the kube controller API is listening on"
+  default     = "6443"
+}
+
+variable "cidr_blocks_api" {
+  description = "list of CIDR blocks that should have access to the kube API"
+  type        = "list"
+}
+
+variable "cidr_blocks_ssh" {
+  description = "list of CIDR blocks that should have access to SSH"
+  type        = "list"
+}
+
+variable "cidr_blocks_etcd" {
+  description = "list of CIDR blocks that should have access to etcd"
+  type        = "list"
+}

--- a/modules/kube-load-balancer-sg/README.md
+++ b/modules/kube-load-balancer-sg/README.md
@@ -1,0 +1,22 @@
+## Kube Load Balancer Security Group
+
+This module defines a security group for controller load balancers in a
+kubernetes cluster. The module adds security group rules to allow access
+to the following:
+
+* the kube controller API
+* open egress for the load balancer nodes
+
+
+### How to use this module
+
+```terraform
+module "kube-load-balancer-sg" {
+  source      = "fpco/foundation/aws//modules/kube-load-balancer-sg"
+  name_prefix = "${var.name}"
+  vpc_id      = "${module.vpc.vpc_id}"
+
+  # omit this to use the default (public access, eg `0.0.0.0/0`)
+  cidr_blocks_api = ["${var.vpc_cidr}", "${var.corporate_network}"]
+}
+```

--- a/modules/kube-load-balancer-sg/main.tf
+++ b/modules/kube-load-balancer-sg/main.tf
@@ -1,0 +1,19 @@
+module "kube-load-balancer-sg" {
+  source      = "../security-group-base"
+  name        = "${var.name_prefix}-${var.name_suffix}"
+  vpc_id      = "${var.vpc_id}"
+  description = "Security group for the ${var.name_prefix} kube load-balancer"
+}
+
+module "api-rule" {
+  source            = "../single-port-sg"
+  port              = "${var.api_port}"
+  description       = "Ingress thru ELB for Kubernetes API, on port ${var.api_port}"
+  cidr_blocks       = ["${var.cidr_blocks_api}"]
+  security_group_id = "${module.kube-load-balancer-sg.id}"
+}
+
+module "open-egress-rule" {
+  source            = "../open-egress-sg"
+  security_group_id = "${module.kube-load-balancer-sg.id}"
+}

--- a/modules/kube-load-balancer-sg/output.tf
+++ b/modules/kube-load-balancer-sg/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+ value = "${module.kube-load-balancer-sg.id}"
+}

--- a/modules/kube-load-balancer-sg/variables.tf
+++ b/modules/kube-load-balancer-sg/variables.tf
@@ -1,0 +1,24 @@
+variable "name_prefix" {
+  description = "Prefix that will be added to names of all resources"
+}
+
+variable "name_suffix" {
+  description = "suffix to include when naming the various resources"
+  default     = "kube-load-balancer"
+}
+
+variable "vpc_id" {
+  description = "VPC id for the security group"
+}
+
+variable "api_port" {
+  description = "TCP port the load balancer should be configured to listen on"
+  default     = "443"
+}
+
+variable "cidr_blocks_api" {
+  description = "list of CIDR blocks that should have access to the kube API"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+

--- a/modules/kube-worker-sg/README.md
+++ b/modules/kube-worker-sg/README.md
@@ -1,0 +1,24 @@
+## Kube Worker Security Group
+
+This module defines a security group for worker nodes in a kubernetes cluster.
+The module adds security group rules to allow access to the following:
+
+* access to all ports on the worker nodes (usually limited to nodes in the VPC)
+* SSH on the kube worker nodes
+* open egress for the worker nodes
+
+
+### How to use this module
+
+```terraform
+module "kube-worker-sg" {
+  source           = "fpco/foundation/aws//modules/kube-worker-sg"
+  version          = "..."
+  name_prefix      = "${var.name}"
+  vpc_id           = "${module.vpc.vpc_id}"
+  cidr_blocks_ssh  = ["${var.corporate_net}"]
+
+  # these networks have access to all ports on the kube worker nodes
+  cidr_blocks_open_ingress = ["${var.vpc_cidr}"]
+}
+```

--- a/modules/kube-worker-sg/main.tf
+++ b/modules/kube-worker-sg/main.tf
@@ -1,0 +1,24 @@
+module "kube-worker-sg" {
+  source      = "../security-group-base"
+  name        = "${var.name_prefix}-${var.name_suffix}"
+  vpc_id      = "${var.vpc_id}"
+  description = "Security group for the ${var.name_prefix} kube worker nodes"
+}
+
+module "private-ssh-rule" {
+  source            = "../ssh-sg"
+  cidr_blocks       = ["${var.cidr_blocks_ssh}"]
+  security_group_id = "${module.kube-worker-sg.id}"
+}
+
+# allow ingress on any port, to kube workers, from any host in the list of CIDR blocks
+module "open-ingress-rule" {
+  source            = "../open-ingress-sg"
+  cidr_blocks       = ["${var.cidr_blocks_open_ingress}"]
+  security_group_id = "${module.kube-worker-sg.id}"
+}
+
+module "open-egress-rule" {
+  source            = "../open-egress-sg"
+  security_group_id = "${module.kube-worker-sg.id}"
+}

--- a/modules/kube-worker-sg/output.tf
+++ b/modules/kube-worker-sg/output.tf
@@ -1,0 +1,3 @@
+output "id" {
+ value = "${module.kube-worker-sg.id}"
+}

--- a/modules/kube-worker-sg/variables.tf
+++ b/modules/kube-worker-sg/variables.tf
@@ -1,0 +1,22 @@
+variable "name_prefix" {
+  description = "Prefix that will be added to names of all resources"
+}
+
+variable "name_suffix" {
+  description = "suffix to include when naming the various resources"
+  default     = "kube-worker"
+}
+
+variable "vpc_id" {
+  description = "VPC id for the security group"
+}
+
+variable "cidr_blocks_ssh" {
+  description = "list of CIDR blocks with access to SSH on the workers"
+  type        = "list"
+}
+
+variable "cidr_blocks_open_ingress" {
+  description = "list of CIDR blocks with access to all ports on the workers"
+  type        = "list"
+}


### PR DESCRIPTION
This PR picks up with @lpaulmp left off in his PR for #78 (https://github.com/fpco/terraform-aws-foundation/pull/82), and primarily renames the variables and updates the use in the public/private kube-stack examples env, but also has a few more subtle changes, like ensuring that the CIDR range used by the load balancer SG is configurable through a variable (`0.0.0.0/0` is a fine default, but with a variable, a user of the module can override it). Same with the `api_port` for kubernetes load balancer and controllers.