### PR TITLE
Update Makefile in vpc-scenario-peering example. The update in this c…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+## Examples
+
+### Getting started
+
+The best way to get started is to read through the README in each example 
+directory.
+
+The examples in this directory are a collection of example enviroments. Each will 
+include a Makefile.

--- a/examples/vpc-scenario-peering/Makefile
+++ b/examples/vpc-scenario-peering/Makefile
@@ -46,8 +46,8 @@ plan:
 	@terraform plan -out=tf.out
 
 ## terraform destroy everything
-destroy-plan:
-	@terraform plan -destroy -out=tf.out
+destroy:
+	@terraform destroy
 
 ## terraform apply
 apply: check-plan-file

--- a/examples/vpc-scenario-peering/README.md
+++ b/examples/vpc-scenario-peering/README.md
@@ -24,7 +24,6 @@ The same test should work from the VCP2-MACHINE as well.
 
 To destroy the test environment run the following commands:
 
-* make destroy-plan
-* make apply
+* make destroy
 * make clean
 


### PR DESCRIPTION
…ommit fixes the problems which caused errors during the destruction of the test environment at the end of the example.

The previous build (with repeatable results) would yield the following error during the `make destroy-plan` step of the example:

```
* module.vpc2-public-subnets.output.azs: cannot parse "${length(var.cidr_blocks)}" as an integer
* module.vpc1-public-subnets.output.azs: cannot parse "${length(var.cidr_blocks)}" as an integer
* module.vpc1-public-subnets.output.cidr_blocks: cannot parse "${length(var.cidr_blocks)}" as an integer
* module.vpc2-public-subnets.output.cidr_blocks: cannot parse "${length(var.cidr_blocks)}" as an integer
* module.vpc2-public-subnets.output.ids: cannot parse "${length(var.cidr_blocks)}" as an integer
* module.vpc1-public-subnets.output.ids: cannot parse "${length(var.cidr_blocks)}" as an integer
``` 

The current updated Makefile for the example addresses this and destroys the test environment as intended. 

(Tested with Terraform version: 0.11.6) 