### PR TITLE
ex/vpc-scenario-1: az bugfix for web instance, #125

### DIFF
--- a/examples/vpc-scenario-1/main.tf
+++ b/examples/vpc-scenario-1/main.tf
@@ -76,10 +76,10 @@ module "open-egress-sg" {
 
 resource "aws_instance" "web" {
   ami               = "${module.ubuntu-xenial-ami.id}"
-  count             = "${length(module.vpc.public_subnet_ids)}"
+  count             = "${length(var.public_subnet_cidrs)}"
   key_name          = "${aws_key_pair.main.key_name}"
   instance_type     = "t2.nano"
-  availability_zone = "${var.region}a"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
 
   root_block_device {
     volume_type = "gp2"


### PR DESCRIPTION
This update addresses two (inter)related issues:

* if we base the web instance count on the number of subnets in use,
  we can use `var.public_subnet_cidrs` instead of `module.vpc.public_subnet_ids`

* drop the hardcoded `availability_zone = "${var.region}a"` and use the data
  source (with `count.index`) in its place.

This resolves #125.