### PR TITLE
gitlab-ci.yml: bump docker build image for tflint 0.6.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.gitlab.fpcomplete.com/fpco/default-build-image:2722
+image: registry.gitlab.fpcomplete.com/fpco/default-build-image:2937
 
 lint:
   script:


### PR DESCRIPTION
This resolves #107:

```
 * [new branch]      107-fix-tflint -> origin/107-fix-tflint
   62e2fbb..3c3b282  s3-full-access-policy-issue122 -> origin/s3-full-access-policy-issue122
Checking out 2282427d as 107-fix-tflint...
Skipping Git submodules setup
$ scripts/ci/tfinit.sh
$ scripts/ci/tflint.sh
Awesome! Your code is following the best practices :)
```

from https://gitlab.fpcomplete.com/fpco-mirrors/terraform-aws-foundation/builds/5485.