### PR TITLE
Add the AWS partition datasource for issue #158

### DIFF
--- a/examples/nexus-asg/nexus.tf
+++ b/examples/nexus-asg/nexus.tf
@@ -33,11 +33,6 @@ variable "key_file" {
   default     = "~/.ssh/id_rsa"
 }
 
-variable "is_govcloud" {
-  description = "If this is running on GovCloud or not"
-  default     = false
-}
-
 module "vpc" {
   source              = "../../modules/vpc-scenario-1"
   azs                 = ["${var.az}"]
@@ -74,7 +69,6 @@ END_INIT
 module "ubuntu-ami" {
   source      = "../../modules/ami-ubuntu"
   release     = "16.04"
-  is_govcloud = "${var.is_govcloud}"
 }
 
 module "init-nexus" {

--- a/modules/ami-ubuntu/main.tf
+++ b/modules/ami-ubuntu/main.tf
@@ -70,11 +70,7 @@ variable "release" {
   type        = "string"
 }
 
-variable "is_govcloud" {
-  default     = false
-  description = "boolean, switch between Canonical's account ARN in `aws_ami.owners`"
-  type        = "string"
-}
+data "aws_partition" "current" {}
 
 data "aws_ami" "ubuntu" {
   most_recent = "${var.most_recent}"
@@ -89,7 +85,7 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["${var.is_govcloud == "true" ? "513442679011" : "099720109477"}"] # Canonical
+  owners = ["${data.aws_partition.current.partition == "aws-us-gov" ? "513442679011" : "099720109477"}"] # Canonical
 }
 
 output "id" {

--- a/modules/bind-server/main.tf
+++ b/modules/bind-server/main.tf
@@ -190,6 +190,9 @@ resource "null_resource" "bind" {
 # Current AWS region
 data "aws_region" "current" {}
 
+# Lookup the current AWS partition
+data "aws_partition" "current" {}
+
 # Cloudwatch alarm that recovers the instance after two minutes of system status check failure
 resource "aws_cloudwatch_metric_alarm" "auto-recover" {
   count               = "${length(compact(var.private_ips))}"
@@ -207,5 +210,5 @@ resource "aws_cloudwatch_metric_alarm" "auto-recover" {
   statistic         = "Minimum"
   threshold         = "0"
   alarm_description = "Auto-recover the instance if the system status check fails for two minutes"
-  alarm_actions     = ["${compact(concat(list("arn:${var.aws_cloud}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
+  alarm_actions     = ["${compact(concat(list("arn:${data.aws_partition.current.partition}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
 }

--- a/modules/bind-server/variables.tf
+++ b/modules/bind-server/variables.tf
@@ -1,9 +1,3 @@
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "ami" {
   description = "AMI to use for instances.  Tested with Ubuntu 16.04."
   type        = "string"

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -21,6 +21,8 @@ resource "aws_s3_bucket" "cloudtrail" {
 
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "cloudtrail-bucket" {
   statement {
     sid    = "AWSCloudTrailAclCheck"
@@ -32,7 +34,7 @@ data "aws_iam_policy_document" "cloudtrail-bucket" {
     }
 
     actions   = ["s3:GetBucketAcl"]
-    resources = ["arn:${var.aws_cloud}:s3:::${var.name_prefix}-cloudtrail"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.name_prefix}-cloudtrail"]
   }
 
   statement {
@@ -45,7 +47,7 @@ data "aws_iam_policy_document" "cloudtrail-bucket" {
     }
 
     actions   = ["s3:PutObject"]
-    resources = ["arn:${var.aws_cloud}:s3:::${var.name_prefix}-cloudtrail/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.name_prefix}-cloudtrail/*"]
 
     condition {
       test     = "StringEquals"

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -3,12 +3,6 @@ variable "name_prefix" {
   type        = "string"
 }
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "kms_key_id" {
   description = "KMS key ARN for encryption of logs"
   default     = ""

--- a/modules/cloudwatch-auto-recover-existing-ec2/main.tf
+++ b/modules/cloudwatch-auto-recover-existing-ec2/main.tf
@@ -7,6 +7,8 @@
 
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_cloudwatch_metric_alarm" "auto-recover" {
   count               = "${length(compact(var.ec2_instance_ids))}"
   alarm_name          = "${format(var.name_format, var.name_prefix, count.index + 1)}"
@@ -23,5 +25,5 @@ resource "aws_cloudwatch_metric_alarm" "auto-recover" {
   statistic         = "Minimum"
   threshold         = "0"
   alarm_description = "Auto-recover the instance if the system status check fails for two minutes"
-  alarm_actions     = ["${compact(concat(list("arn:${var.aws_cloud}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
+  alarm_actions     = ["${compact(concat(list("arn:${data.aws_partition.current.partition}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
 }

--- a/modules/cloudwatch-auto-recover-existing-ec2/variables.tf
+++ b/modules/cloudwatch-auto-recover-existing-ec2/variables.tf
@@ -1,9 +1,3 @@
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "name_prefix" {
   description = "Name to be prefixed to all resources"
   default     = ""

--- a/modules/consul-demo-server/main.tf
+++ b/modules/consul-demo-server/main.tf
@@ -12,7 +12,6 @@ module "consul-server" {
   source                  = "../single-node-asg"
   name_prefix             = "${var.name_prefix}"
   name_suffix             = "consul-server"
-  aws_cloud               = "${var.aws_cloud}"
   region                  = "${var.region}"
   root_volume_type        = "gp2"
   root_volume_size        = "8"

--- a/modules/consul-demo-server/variables.tf
+++ b/modules/consul-demo-server/variables.tf
@@ -67,8 +67,3 @@ variable "load_balancers" {
   default     = []
   description = "The list of load balancers names to pass to the ASG module"
 }
-
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-}

--- a/modules/credstash-setup/data.tf
+++ b/modules/credstash-setup/data.tf
@@ -2,6 +2,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 data "template_file" "credstash-get-cmd" {
   template = "env credstash -r ${data.aws_region.current.name} -t ${var.db_table_name} get"
 }
@@ -26,7 +28,7 @@ data "aws_iam_policy_document" "writer-policy" {
     actions = ["dynamodb:PutItem"]
 
     resources = [
-      "arn:${var.aws_cloud}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.db_table_name}",
+      "arn:${data.aws_partition.current.partition}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.db_table_name}",
     ]
   }
 }
@@ -43,7 +45,7 @@ data "aws_iam_policy_document" "reader-policy" {
     ]
 
     resources = [
-      "arn:${var.aws_cloud}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.db_table_name}",
+      "arn:${data.aws_partition.current.partition}:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.db_table_name}",
     ]
   }
 }

--- a/modules/credstash-setup/variables.tf
+++ b/modules/credstash-setup/variables.tf
@@ -1,9 +1,3 @@
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "create_kms_key" {
   default     = true
   description = "Should the Master key be created"

--- a/modules/cross-account-assume-role-policy/main.tf
+++ b/modules/cross-account-assume-role-policy/main.tf
@@ -10,12 +10,6 @@
  *
  */
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "policy_name" {
   description = "Name of the policy."
   type        = "string"
@@ -49,14 +43,16 @@ output "arn" {
   value = "${aws_iam_policy.assume-role.arn}"
 }
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "assume-role" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     resources = [
-      "${formatlist("arn:${var.aws_cloud}:iam::%s:role/%s",var.account_ids,var.role_name)}",
-      "${formatlist("arn:${var.aws_cloud}:iam::%s:role/%s",var.account_id,var.role_names)}",
+      "${formatlist("arn:${data.aws_partition.current.partition}:iam::%s:role/%s",var.account_ids,var.role_name)}",
+      "${formatlist("arn:${data.aws_partition.current.partition}:iam::%s:role/%s",var.account_id,var.role_names)}",
     ]
   }
 }

--- a/modules/cross-account-group/main.tf
+++ b/modules/cross-account-group/main.tf
@@ -5,12 +5,6 @@
  *
  */
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "name" {
   description = "name of the group"
   type        = "string"
@@ -50,7 +44,6 @@ resource "aws_iam_group_policy_attachment" "manage-own-credentials-with-mfa" {
 
 module "assume-group-role-policy" {
   source      = "../cross-account-assume-role-policy"
-  aws_cloud   = "${var.aws_cloud}"
   policy_name = "assume-${var.name}-${var.role_name}-role"
   role_name   = "${var.role_name}"
   account_ids = ["${var.account_ids}"]

--- a/modules/cross-account-role/main.tf
+++ b/modules/cross-account-role/main.tf
@@ -6,12 +6,6 @@
  *
  */
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "trust_account_ids" {
   description = "List of other accounts to trust to assume the role"
   default     = []
@@ -33,6 +27,8 @@ output "name" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "assume-role" {
   statement {
     effect  = "Allow"
@@ -46,7 +42,7 @@ data "aws_iam_policy_document" "assume-role" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${formatlist("arn:${var.aws_cloud}:iam::%s:root",var.trust_account_ids)}"]
+      identifiers = ["${formatlist("arn:${data.aws_partition.current.partition}:iam::%s:root",var.trust_account_ids)}"]
     }
   }
 }

--- a/modules/dnsmasq-server/main.tf
+++ b/modules/dnsmasq-server/main.tf
@@ -138,6 +138,9 @@ resource "null_resource" "dnsmasq" {
 # Current AWS region
 data "aws_region" "current" {}
 
+# Lookup the current AWS partition
+data "aws_partition" "current" {}
+
 # Cloudwatch alarm that recovers the instance after two minutes of system status
 # check failure
 resource "aws_cloudwatch_metric_alarm" "auto-recover" {
@@ -156,5 +159,5 @@ resource "aws_cloudwatch_metric_alarm" "auto-recover" {
   statistic         = "Minimum"
   threshold         = "0"
   alarm_description = "Auto-recover the instance if the system status check fails for two minutes"
-  alarm_actions     = ["${compact(concat(list("arn:${var.aws_cloud}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
+  alarm_actions     = ["${compact(concat(list("arn:${data.aws_partition.current.partition}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
 }

--- a/modules/dnsmasq-server/variables.tf
+++ b/modules/dnsmasq-server/variables.tf
@@ -3,12 +3,6 @@ variable "ami" {
   type        = "string"
 }
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "instance_type" {
   description = "Type of instance to run the DNS servers"
   default     = "t2.nano"

--- a/modules/ec2-auto-recover-instances/main.tf
+++ b/modules/ec2-auto-recover-instances/main.tf
@@ -108,6 +108,9 @@ resource "aws_instance" "auto-recover" {
 # Current AWS region
 data "aws_region" "current" {}
 
+# Lookup the current AWS partition
+data "aws_partition" "current" {}
+
 # Cloudwatch alarm that recovers the instance after two minutes of system status
 # check failure
 resource "aws_cloudwatch_metric_alarm" "auto-recover" {
@@ -126,5 +129,5 @@ resource "aws_cloudwatch_metric_alarm" "auto-recover" {
   statistic         = "${var.statistic}"
   threshold         = "${var.threshold}"
   alarm_description = "${var.alarm_description}"
-  alarm_actions     = ["${compact(concat(list("arn:${var.aws_cloud}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
+  alarm_actions     = ["${compact(concat(list("arn:${data.aws_partition.current.partition}:automate:${data.aws_region.current.name}:ec2:recover"), "${var.alarm_actions}"))}"]
 }

--- a/modules/ec2-auto-recover-instances/variables.tf
+++ b/modules/ec2-auto-recover-instances/variables.tf
@@ -3,12 +3,6 @@ variable "ami" {
   type        = "string"
 }
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "extra_tags" {
   description = "map of tags to append to the Name tag, added to the instance"
   default     = {}

--- a/modules/ec2-nat-instances/main.tf
+++ b/modules/ec2-nat-instances/main.tf
@@ -15,7 +15,6 @@
 module "ubuntu-ami" {
   source      = "../ami-ubuntu"
   release     = "16.04"
-  is_govcloud = "${var.aws_cloud == "aws-us-gov" ? "true" : "false"}" # Canonical
 }
 
 # boxed module to update the EC2 node's hostname
@@ -65,7 +64,6 @@ module "ec2-nat" {
   name_prefix        = "${var.name_prefix}"
   name_format        = "%s-ec2-nat-%02d"
   extra_tags         = "${var.extra_tags}"
-  aws_cloud          = "${var.aws_cloud}"
   ami                = "${module.ubuntu-ami.id}"
   key_name           = "${var.key_name}"
   instance_type      = "${var.instance_type}"

--- a/modules/ec2-nat-instances/variables.tf
+++ b/modules/ec2-nat-instances/variables.tf
@@ -1,9 +1,3 @@
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "instance_type" {
   description = "AWS instance type, use larger instances for high-volume traffic"
   default     = "t2.nano"

--- a/modules/elasticsearch/data-nodes.tf
+++ b/modules/elasticsearch/data-nodes.tf
@@ -10,7 +10,6 @@
  */
 
 module "data-node-ebs-volumes" {
-  aws_cloud    = "${var.is_govcloud ? "aws-us-gov" : "aws"}"
   source       = "../persistent-ebs-volumes"
   name_prefix  = "${var.name_prefix}-data-node"
   volume_count = "${var.data_node_count}"

--- a/modules/elasticsearch/master-nodes.tf
+++ b/modules/elasticsearch/master-nodes.tf
@@ -7,7 +7,6 @@
  */
 
 module "master-node-ebs-volumes" {
-  aws_cloud    = "${var.is_govcloud ? "aws-us-gov" : "aws"}"
   source       = "../persistent-ebs-volumes"
   name_prefix  = "${var.name_prefix}-master-node"
   volume_count = "${var.master_node_count}"

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -1,9 +1,3 @@
-variable "is_govcloud" {
-  description = "Boolean, is it running on GovCloud"
-  default     = false
-  type        = "string"
-}
-
 variable "name_prefix" {
   default = "dev"
   type        = "string"

--- a/modules/elk-stack/main.tf
+++ b/modules/elk-stack/main.tf
@@ -18,7 +18,6 @@
 module "ubuntu-ami" {
   source      = "../ami-ubuntu"
   release     = "16.04"
-  is_govcloud = "${var.is_govcloud}"
 }
 
 data "aws_vpc" "current" {
@@ -49,7 +48,6 @@ resource "aws_security_group" "ssh" {
 module "elasticsearch" {
   source = "../elasticsearch"
 
-  is_govcloud                 = "${var.is_govcloud}"
   name_prefix                 = "${var.name_prefix}"
   vpc_id                      = "${var.vpc_id}"
   key_name                    = "${var.ssh_key_name}"

--- a/modules/elk-stack/variables.tf
+++ b/modules/elk-stack/variables.tf
@@ -4,12 +4,6 @@ variable "name_prefix" {
   type        = "string"
 }
 
-variable "is_govcloud" {
-  description = "Boolean, if this is running on GovCloud or not"
-  default     = "false"
-  type        = "string"
-}
-
 variable "vpc_id" {
   description = "VPC ID for the ELK stack"
   type        = "string"

--- a/modules/persistent-ebs-volumes/iam.tf
+++ b/modules/persistent-ebs-volumes/iam.tf
@@ -2,6 +2,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_policy" "ebs-volume-policy" {
   count  = "${var.volume_count}"
   name   = "${var.name_prefix}-ebs-volume-${count.index + 1}"
@@ -18,8 +20,8 @@ data "aws_iam_policy_document" "ebs-volume-policy" {
     ]
 
     resources = [
-      "arn:${var.aws_cloud}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.volumes.*.id, count.index)}",
-      "arn:${var.aws_cloud}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.volumes.*.id, count.index)}",
+      "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*",
     ]
   }
 }

--- a/modules/persistent-ebs-volumes/variables.tf
+++ b/modules/persistent-ebs-volumes/variables.tf
@@ -55,8 +55,3 @@ variable "extra_tags" {
   default     = {}
   description = "Map with extra tags to be applied to all ebs volumes"
 }
-
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-}

--- a/modules/persistent-ebs/data.tf
+++ b/modules/persistent-ebs/data.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "attach_ebs" {
   statement {
     sid    = ""
@@ -25,8 +27,8 @@ data "aws_iam_policy_document" "attach_ebs_policy" {
     ]
 
     resources = [
-      "arn:${var.aws_cloud}:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${aws_ebs_volume.main.id}",
-      "arn:${var.aws_cloud}:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:instance/*",
+      "arn:${data.aws_partition.current.partition}:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${aws_ebs_volume.main.id}",
+      "arn:${data.aws_partition.current.partition}:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:instance/*",
     ]
   }
 }

--- a/modules/persistent-ebs/variables.tf
+++ b/modules/persistent-ebs/variables.tf
@@ -55,9 +55,3 @@ variable "extra_tags" {
   description = "Map with extra tags to be applied to all ebs volumes"
   type        = "map"
 }
-
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}

--- a/modules/s3-full-access-policy/main.tf
+++ b/modules/s3-full-access-policy/main.tf
@@ -11,11 +11,6 @@ variable "bucket_names" {
   type        = "list"
 }
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-}
-
 output "id" {
   value       = "${aws_iam_policy.s3-full-access.id}"
   description = "`id` exported from `aws_iam_policy`"
@@ -31,6 +26,8 @@ output "name" {
   description = "`name` exported from `aws_iam_policy`"
 }
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "s3-full-access" {
   statement {
     effect = "Allow"
@@ -41,7 +38,7 @@ data "aws_iam_policy_document" "s3-full-access" {
       "s3:ListBucketMultipartUploads",
     ]
 
-    resources = ["${formatlist("arn:${var.aws_cloud}:s3:::%s",var.bucket_names)}"]
+    resources = ["${formatlist("arn:${data.aws_partition.current.partition}:s3:::%s",var.bucket_names)}"]
   }
 
   statement {
@@ -57,7 +54,7 @@ data "aws_iam_policy_document" "s3-full-access" {
       "s3:AbortMultipartUpload",
     ]
 
-    resources = ["${formatlist("arn:${var.aws_cloud}:s3:::%s/*",var.bucket_names)}"]
+    resources = ["${formatlist("arn:${data.aws_partition.current.partition}:s3:::%s/*",var.bucket_names)}"]
   }
 }
 

--- a/modules/s3-remote-state/main.tf
+++ b/modules/s3-remote-state/main.tf
@@ -27,11 +27,6 @@ variable "region" {
   type        = "string"
 }
 
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-}
-
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "remote-state" {
@@ -43,6 +38,9 @@ resource "aws_s3_bucket" "remote-state" {
     enabled = "${var.versioning}"
   }
 }
+
+# Lookup the current AWS partition
+data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "s3-full-access" {
   statement {
@@ -59,7 +57,7 @@ data "aws_iam_policy_document" "s3-full-access" {
       identifiers = ["${compact(var.principals)}"]
     }
 
-    resources = ["arn:${var.aws_cloud}:s3:::${aws_s3_bucket.remote-state.id}"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.remote-state.id}"]
   }
 
   statement {
@@ -85,7 +83,7 @@ data "aws_iam_policy_document" "s3-full-access" {
       identifiers = ["${compact(var.principals)}"]
     }
 
-    resources = ["arn:${var.aws_cloud}:s3:::${aws_s3_bucket.remote-state.id}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.remote-state.id}/*"]
   }
 }
 
@@ -104,7 +102,7 @@ data "aws_iam_policy_document" "bucket-full-access" {
       "s3:ListBucketMultipartUploads",
     ]
 
-    resources = ["arn:${var.aws_cloud}:s3:::${aws_s3_bucket.remote-state.id}"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.remote-state.id}"]
   }
 
   statement {
@@ -118,7 +116,7 @@ data "aws_iam_policy_document" "bucket-full-access" {
       "s3:AbortMultipartUpload",
     ]
 
-    resources = ["arn:${var.aws_cloud}:s3:::${aws_s3_bucket.remote-state.id}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.remote-state.id}/*"]
   }
 }
 
@@ -137,7 +135,7 @@ data "aws_iam_policy_document" "bucket-full-access-with-mfa" {
       "s3:ListBucketMultipartUploads",
     ]
 
-    resources = ["arn:${var.aws_cloud}:s3:::${aws_s3_bucket.remote-state.id}"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.remote-state.id}"]
   }
 
   statement {
@@ -151,7 +149,7 @@ data "aws_iam_policy_document" "bucket-full-access-with-mfa" {
       "s3:AbortMultipartUpload",
     ]
 
-    resources = ["arn:${var.aws_cloud}:s3:::${aws_s3_bucket.remote-state.id}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.remote-state.id}/*"]
 
     condition {
       test     = "Bool"

--- a/modules/setup-meta-infrastructure/data.tf
+++ b/modules/setup-meta-infrastructure/data.tf
@@ -1,0 +1,2 @@
+# Lookup the current AWS partition
+data "aws_partition" "current" {}

--- a/modules/setup-meta-infrastructure/policies.tf
+++ b/modules/setup-meta-infrastructure/policies.tf
@@ -50,7 +50,6 @@ resource "aws_iam_policy" "admin-no-mfa" {
 
 module "assume-admin-role-policy" {
   source      = "../cross-account-assume-role-policy"
-  aws_cloud   = "${var.aws_cloud}"
   policy_name = "assume-control-accounts-admin-role"
   role_name   = "${module.admin-role.name}"
 
@@ -140,7 +139,6 @@ resource "aws_iam_policy" "power-user-no-mfa" {
 
 module "assume-power-user-role-policy" {
   source      = "../cross-account-assume-role-policy"
-  aws_cloud   = "${var.aws_cloud}"
   policy_name = "assume-control-accounts-power-user-role"
   role_name   = "${module.power-user-role.name}"
 
@@ -159,7 +157,7 @@ data "aws_iam_policy_document" "setup-mfa" {
     sid       = "AllowUsersToCreateDeleteTheirOwnVirtualMFADevices"
     effect    = "Allow"
     actions   = ["iam:*VirtualMFADevice"]
-    resources = ["arn:${var.aws_cloud}:iam::${data.aws_caller_identity.current.account_id}:mfa/&{aws:username}"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:mfa/&{aws:username}"]
   }
 
   statement {
@@ -174,7 +172,7 @@ data "aws_iam_policy_document" "setup-mfa" {
       "iam:ChangePassword",
     ]
 
-    resources = ["arn:${var.aws_cloud}:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
   }
 
   statement {
@@ -188,14 +186,14 @@ data "aws_iam_policy_document" "setup-mfa" {
     sid       = "AllowUsersToListVirtualMFADevices"
     effect    = "Allow"
     actions   = ["iam:ListVirtualMFADevices"]
-    resources = ["arn:${var.aws_cloud}:iam::${data.aws_caller_identity.current.account_id}:mfa/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:mfa/*"]
   }
 
   statement {
     sid       = "AllowUsersToListUsersInConsole"
     effect    = "Allow"
     actions   = ["iam:ListUsers"]
-    resources = ["arn:${var.aws_cloud}:iam::${data.aws_caller_identity.current.account_id}:user/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/*"]
   }
 }
 
@@ -216,7 +214,7 @@ data "aws_iam_policy_document" "manage-own-credentials-with-mfa" {
       "iam:ChangePassword",
     ]
 
-    resources = ["arn:${var.aws_cloud}:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
 
     condition {
       test     = "Bool"

--- a/modules/setup-meta-infrastructure/roles.tf
+++ b/modules/setup-meta-infrastructure/roles.tf
@@ -4,7 +4,6 @@
 
 module "admin-role" {
   source    = "../cross-account-role"
-  aws_cloud = "${var.aws_cloud}"
   name      = "admin"
 
   trust_account_ids = [
@@ -15,7 +14,6 @@ module "admin-role" {
 
 module "power-user-role" {
   source    = "../cross-account-role"
-  aws_cloud = "${var.aws_cloud}"
   name      = "power-user"
 
   trust_account_ids = [

--- a/modules/setup-meta-infrastructure/variables.tf
+++ b/modules/setup-meta-infrastructure/variables.tf
@@ -1,9 +1,3 @@
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}
-
 variable "create_groups" {
   description = "Set to 0 to disable creating the 'admin', 'power-user', and 'setup-mfa' groups.  This should be done for accounts that users do not sign into directly (only delegated access)."
   default     = 1

--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -14,7 +14,6 @@
 module "service-data" {
   source      = "../persistent-ebs"
   name_prefix = "${var.name_prefix}-${var.name_suffix}-data"
-  aws_cloud   = "${var.aws_cloud}"
   region      = "${var.region}"
   az          = "${data.aws_subnet.server-subnet.availability_zone}"
   size        = "${var.data_volume_size}"

--- a/modules/single-node-asg/variables.tf
+++ b/modules/single-node-asg/variables.tf
@@ -115,9 +115,3 @@ variable "load_balancers" {
   description = "The list of load balancers names to pass to the ASG module"
   type        = "list"
 }
-
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}

--- a/modules/snapshot-bucket/data.tf
+++ b/modules/snapshot-bucket/data.tf
@@ -1,3 +1,5 @@
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "s3" {
   statement {
     effect    = "Allow"
@@ -15,6 +17,6 @@ data "aws_iam_policy_document" "s3" {
       "s3:CreateMultipartUpload",
     ]
 
-    resources = ["arn:${var.aws_cloud}:s3:::${var.name}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.name}/*"]
   }
 }

--- a/modules/snapshot-bucket/variables.tf
+++ b/modules/snapshot-bucket/variables.tf
@@ -2,9 +2,3 @@ variable "name" {
   description = "Name to give bucket"
   type        = "string"
 }
-
-variable "aws_cloud" {
-  description = "set to 'aws-us-gov' if using GovCloud, otherwise leave the default"
-  default     = "aws"
-  type        = "string"
-}


### PR DESCRIPTION
This should be able to close issue #158 

This uses the `aws_partition` data source in place of the the `aws_cloud` variable.

I believe this commit is comprehensive but there may be one that I missed. 