### PR TITLE
Respect the user's preferred shell when spawing an interactive shell

### DIFF
--- a/examples/gitlab-ha/Makefile
+++ b/examples/gitlab-ha/Makefile
@@ -28,7 +28,7 @@ all:
 
 ## Run an interactive shell with all environment variables defined
 shell:
-	@bash
+	@exec $${SHELL}
 
 ## Use envsubst to render the json config files for cfssl
 render-tls-configs:


### PR DESCRIPTION
This is a minor improvement that came out of our discussion about the Synesis Makefile

The source branch can be removed after merging