### PR TITLE
[cross-account-role] Fix typo

### DIFF
--- a/modules/cross-account-role/main.tf
+++ b/modules/cross-account-role/main.tf
@@ -13,7 +13,7 @@ variable "trust_account_ids" {
 }
 
 variable "name" {
-  description = "Name to give the roll"
+  description = "Name to give the role"
   type        = "string"
 }
 


### PR DESCRIPTION
Fix small typo in the description of a name variable in the `cross-account-role`
