### PR TITLE
Fix interpolation for the tf template provider version 2.0.0

### DIFF
--- a/modules/init-snippet-attach-ebs-volume/snippet.tpl
+++ b/modules/init-snippet-attach-ebs-volume/snippet.tpl
@@ -2,11 +2,11 @@
 ${init_prefix}
 export AWS_DEFAULT_REGION=${region}
 VOLUME_ID=${volume_id}
-INSTANCE_ID=$$(ec2metadata --instance-id)
-echo "${log_prefix} will attach $$VOLUME_ID via the AWS API in ${region}"
+INSTANCE_ID=$(ec2metadata --instance-id)
+echo "${log_prefix} will attach $VOLUME_ID via the AWS API in ${region}"
 aws ec2 attach-volume                \
-          --volume-id $$VOLUME_ID     \
-          --instance-id $$INSTANCE_ID \
+          --volume-id $VOLUME_ID     \
+          --instance-id $INSTANCE_ID \
           --device ${device_path}
 
 ls ${device_path}

--- a/modules/logstash/data/certs.tpl.sh
+++ b/modules/logstash/data/certs.tpl.sh
@@ -5,7 +5,7 @@ set -xe
 LOGSTASH_CLIENT_NAME="logstash-client"
 
 if [ -z "${depot_path}" ]; then
-  DEPOT_PATH=$$(mktemp -d)
+  DEPOT_PATH=$(mktemp -d)
 else
   DEPOT_PATH="${depot_path}"
 fi

--- a/modules/persistent-ebs-volumes/snippet.tpl.sh
+++ b/modules/persistent-ebs-volumes/snippet.tpl.sh
@@ -2,22 +2,22 @@
 MAX_SLEEP=${max_wait}
 TOTAL_SLEEP=0
 VOLUME_ID=${volume_id}
-INSTANCE_ID=$$(ec2metadata --instance-id)
-REGION=$$(ec2metadata --availability-zone | sed 's/.$//')
-echo "Attaching $$VOLUME_ID to instance $$INSTANCE_ID via the AWS API in $${REGION}"
-aws --region=$${REGION}         \
+INSTANCE_ID=$(ec2metadata --instance-id)
+REGION=$(ec2metadata --availability-zone | sed 's/.$//')
+echo "Attaching $VOLUME_ID to instance $INSTANCE_ID via the AWS API in $REGION"
+aws --region=$REGION         \
     ec2 attach-volume           \
-    --volume-id $$VOLUME_ID     \
-    --instance-id $$INSTANCE_ID \
+    --volume-id $VOLUME_ID     \
+    --instance-id $INSTANCE_ID \
     --device ${device_name}
 
 ls ${device_name}
-while [ $$? -ne 0 ]; do
-  if [ "$$TOTAL_SLEEP" -gt "$$MAX_SLEEP" ]; then
-    echo "Was unable to attach volume within limit time of $$MAX_SLEEP seconds."
+while [ $? -ne 0 ]; do
+  if [ "$TOTAL_SLEEP" -gt "$MAX_SLEEP" ]; then
+    echo "Was unable to attach volume within limit time of $MAX_SLEEP seconds."
     exit 1
   fi
-  TOTAL_SLEEP=$$((TOTAL_SLEEP + ${wait_interval}))
+  TOTAL_SLEEP=$((TOTAL_SLEEP + ${wait_interval}))
   sleep ${wait_interval}
   ls ${device_name}
 done


### PR DESCRIPTION
Issue #185
Fix interpolation for the tf template provider version 2.0.0, remove the extra $ for bash interpolations - Dollar sign escaping is only needed as part of escaping the full ${ sequence, not dollar signs in isolation.

Output:
---
module `init-snippet-attach-ebs-volume`
```
[terraform-aws-foundation/modules/init-snippet-attach-ebs-volume]§ terraform init

Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "template" (2.0.0)...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
```
[terraform-aws-foundation/modules/init-snippet-attach-ebs-volume]§ terraform plan
var.region
  AWS region the volume is in

  Enter a value: global

var.volume_id
  ID of the EBS volume to attach

  Enter a value: 12344

Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.template_file.init_snippet: Refreshing state...

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.  
```
---
module `persistent-ebs-volumes`
```
[terraform-aws-foundation/modules/persistent-ebs-volumes]§ terraform init                                                                                  

Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "aws" (1.57.0)...
- Downloading plugin for provider "template" (2.0.0)...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 1.57"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
```
[terraform-aws-foundation/modules/persistent-ebs-volumes]§ terraform plan
var.azs
  AWS Availability Zones (AZs) to create the volumes in

  Enter a value: ["1"]

var.name_prefix
  The name prefix EBS for volumes

  Enter a value: ebs

var.snapshot_ids
  IDs of the snapshots to base the EBS block devices on

  Enter a value: ["id"]

var.volume_count
  How many EBS volumes should be deployed accross all AZs

  Enter a value: 1

Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.current: Refreshing state...

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

 <= data.aws_iam_policy_document.ebs-volume-policy
      id:                             <computed>
      json:                           <computed>
      statement.#:                    "1"
      statement.0.actions.#:          "2"
      statement.0.actions.1116652165: "ec2:AttachVolume"
      statement.0.actions.3357331461: "ec2:DetachVolume"                                                                                                                                                                                                                                     
      statement.0.effect:             "Allow"                                                                                                                                                                                                                                                
      statement.0.resources.#:        <computed>                                                                                                                                                                                                                                             
      version:                        "2012-10-17"

 <= data.template_file.volume_mount_snippets
      id:                             <computed>
      rendered:                       <computed>
      template:                       "# Mount volume\nMAX_SLEEP=${max_wait}\nTOTAL_SLEEP=0\nVOLUME_ID=${volume_id}\nINSTANCE_ID=$(ec2metadata --instance-id)\nREGION=$(ec2metadata --availability-zone | sed 's/.$//')\necho \"Attaching $VOLUME_ID to instance $INSTANCE_ID via the AWS API
in $REGION\"\naws --region=$REGION         \\\n    ec2 attach-volume           \\\n    --volume-id $VOLUME_ID     \\\n    --instance-id $INSTANCE_ID \\\n    --device ${device_name}\n\nls ${device_name}\nwhile [ $? -ne 0 ]; do\n  if [ \"$TOTAL_SLEEP\" -gt \"$MAX_SLEEP\" ]; then\n    echo \"Was unable to attach volume within limit time of $MAX_SLEEP seconds.\"\n    exit 1\n  fi\n  TOTAL_SLEEP=$((TOTAL_SLEEP + ${wait_interval}))\n  sleep ${wait_interval}\n  ls ${device_name}\ndone\n"                                                                                      
      vars.%:                         <computed>

  + aws_ebs_volume.volumes
      id:                             <computed>
      arn:                            <computed>
      availability_zone:              "1"
      encrypted:                      "false"
      iops:                           <computed>
      kms_key_id:                     <computed>
      size:                           "15"
      snapshot_id:                    "id"
      tags.%:                         "1"
      tags.Name:                      "ebs-01-1"
      type:                           "gp2"

  + aws_iam_policy.ebs-volume-policy
      id:                             <computed>
      arn:                            <computed>
      name:                           "ebs-ebs-volume-1"
      path:                           "/"
      policy:                         "${data.aws_iam_policy_document.ebs-volume-policy.json}"


Plan: 2 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```
---
module `logstash`
```
[terraform-aws-foundation/modules/logstash]§ terraform init
Initializing modules...
- module.credstash-grant

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```
```
[terraform-aws-foundation/modules/logstash]§ terraform plan
var.ami
  AMI to use for instances running Logstash

  Enter a value: ami

var.credstash_get_cmd
  Credstash get command with region and table values set.

  Enter a value: cmd

var.credstash_install_snippet
  Ubuntu bash script snippet for installing credstash and its dependencies

  Enter a value: var

var.credstash_kms_key_arn
  Master KMS key ARN for getting SSL server key using credstash

  Enter a value: key

var.credstash_put_cmd
  Credstash put command with region, table and kms key values set.

  Enter a value: c,d

var.credstash_reader_policy_arn
  Secrets Reader Policy ARN that was created by 'credstash-setup' module. Reading will be disabled if not supplied.

  Enter a value: var

var.elasticsearch_url
  Elasticsearch endpoint url

  Enter a value: var

var.key_name
  SSH key name to use for connecting to all nodes

  Enter a value: name

var.logstash_dns_name
  DNS name for Logstash endpoint

  Enter a value: dns

var.logstash_version
  Which version of Logstash to install

  Enter a value: 123

var.private_subnet_ids
  A list of private subnet ids to deploy Logstash servers in

  Enter a value: ["123"]

var.public_subnet_ids
  A list of public subnet ids to deploy Logstash ELB in

  Enter a value: ["1234"]

var.vpc_id
  VPC id where Logstash servers should be deployed in

  Enter a value: vpc

provider.aws.region
  The region where AWS operations will take place. Examples
  are us-east-1, us-west-2, etc.

  Default: us-east-1
  Enter a value: global


Error: data.aws_iam_policy_document.logstash-role: statement.0: invalid or unknown key: action
Error: data.aws_iam_policy_document.logstash-role: statement.0: invalid or unknown key: principal
```
