### PR TITLE
Add ubuntu 18.04 LTS in the list of ubuntu releases

### DIFF
--- a/modules/ami-ubuntu/main.tf
+++ b/modules/ami-ubuntu/main.tf
@@ -54,6 +54,7 @@ variable "most_recent" {
 
 variable "name_map" {
   default = {
+    "18.04" = "bionic"
     "17.10" = "artful"
     "17.04" = "zesty"
     "16.04" = "xenial"


### PR DESCRIPTION
Closes #191 

Output
```
terraform plan -var release=18.04    
Refreshing Terraform state in-memory prior to plan...                                                                                                         
The refreshed state will be used to calculate this plan, but will not be                                                                                      
persisted to local or remote state storage.                                                                                                                   
                                                                                                                                                              
data.aws_partition.current: Refreshing state...                                                                                                               
data.aws_ami.ubuntu: Refreshing state...                                                                                                                      
                                                                                                                                                              
------------------------------------------------------------------------                                                                                      
                                                                                                                                                              
No changes. Infrastructure is up-to-date.   
```
```
§ terraform apply -var release=18.04   
data.aws_partition.current: Refreshing state...                                                                                                               
data.aws_ami.ubuntu: Refreshing state...                                                                                                                      
                                                                                                                                                              
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.                                                                                                   
                                                                                                                                                              
Outputs:                                                                                                                                                      
                                                                                                                                                              
id = ami-0a313d6098716f372
```

The AMI exists when look for it in the dasboard, the first in the list the AMI ID that terraform shows as output:
<img width="1209" alt="Screen Shot 2019-03-14 at 16 41 20" src="https://user-images.githubusercontent.com/4852949/54393434-29093580-4678-11e9-9f88-4b01a61d2b8a.png">
