### PR TITLE
add modules for credstash reader/writer grants

### DIFF
--- a/modules/credstash-grant-reader/README.md
+++ b/modules/credstash-grant-reader/README.md
@@ -1,0 +1,4 @@
+## Credstash Grant Reader Access
+
+This module will make it possible for anybody assuming the supplied IAM Role to read
+secrets from a credstash store.

--- a/modules/credstash-grant-reader/main.tf
+++ b/modules/credstash-grant-reader/main.tf
@@ -1,0 +1,56 @@
+variable "kms_key_arn" {
+  description = "ARN for the KMS Master key created by 'credstash-setup' module"
+  type        = "string"
+}
+
+// Roles count is only necessary to circumvent [terraform #4149](https://github.com/hashicorp/terraform/issues/4149) issue.
+variable "role_count" {
+  description = "Number of roles that will be used during a grant process, i.e. how many roles_names there is."
+  type        = "string"
+}
+
+variable "role_names" {
+  type        = "list"
+  description = "Role Name for which reading secrets will be enabled. Must correspond 1:1 with roles_arns"
+}
+
+variable "role_arns" {
+  type        = "list"
+  description = "Role ARN for which reading secrets will be enabled. Must correspond 1:1 with roles_names"
+}
+
+variable "reader_policy_arn" {
+  description = "Secrets Reader Policy ARN that was created by 'credstash-setup' module"
+  type        = "string"
+}
+
+variable "context_keys" {
+  default     = []
+  description = "list of keys to be zipped with the context_values to set an 'encryption context' for additional granularity that clients are required to provide to read encrypted values. Eg. for env=dev svc=db, this would be [env, svc]. All readers get this context map."
+  type        = "list"
+}
+
+variable "context_values" {
+  default     = []
+  description = "list of values to be zipped with the context_keys to set an 'encryption context' for additional granularity that clients are required to provide to read encrypted values. Eg. for env=dev svc=db, this would be [dev, db]. All readers get this context map."
+  type        = "list"
+}
+
+resource "aws_iam_role_policy_attachment" "credstash-reader-policy-attachment" {
+  count      = "${var.role_count}"
+  role       = "${var.role_names[count.index]}"
+  policy_arn = "${var.reader_policy_arn}"
+}
+
+resource "aws_kms_grant" "credstash-reader" {
+  count             = "${var.role_count}"
+  name              = "${var.role_names[count.index]}-credstash-reader"
+  grantee_principal = "${var.role_arns[count.index]}"
+  key_id            = "${var.kms_key_arn}"
+  operations        = ["Decrypt"]
+
+  constraints {
+    encryption_context_equals = "${map(element(var.context_keys, count.index),
+                                       element(var.context_values, count.index))}"
+ }
+}

--- a/modules/credstash-grant-writer/README.md
+++ b/modules/credstash-grant-writer/README.md
@@ -1,0 +1,4 @@
+## Credstash Grant Writer Access
+
+This module will make it possible for anybody assuming the supplied IAM Role to
+write secrets to a credstash store.

--- a/modules/credstash-grant-writer/main.tf
+++ b/modules/credstash-grant-writer/main.tf
@@ -1,0 +1,56 @@
+variable "kms_key_arn" {
+  description = "ARN for the KMS Master key created by 'credstash-setup' module"
+  type        = "string"
+}
+
+// Roles count is only necessary to circumvent [terraform #4149](https://github.com/hashicorp/terraform/issues/4149) issue.
+variable "role_count" {
+  description = "Number of roles that will be used during a grant process, i.e. how many roles_names there is."
+  type        = "string"
+}
+
+variable "role_names" {
+  type        = "list"
+  description = "Role Name for which reading secrets will be enabled. Must correspond 1:1 with roles_arns"
+}
+
+variable "role_arns" {
+  type        = "list"
+  description = "Role ARN for which reading secrets will be enabled. Must correspond 1:1 with roles_names"
+}
+
+variable "writer_policy_arn" {
+  description = "Secrets Reader Policy ARN that was created by 'credstash-setup' module"
+  type        = "string"
+}
+
+variable "context_keys" {
+  default     = []
+  description = "list of keys to be zipped with the context_values to set an 'encryption context' for additional granularity that clients are required to provide to read encrypted values. Eg. for env=dev svc=db, this would be [env, svc]. All writers get this context map."
+  type        = "list"
+}
+
+variable "context_values" {
+  default     = []
+  description = "list of values to be zipped with the context_keys to set an 'encryption context' for additional granularity that clients are required to provide to read encrypted values. Eg. for env=dev svc=db, this would be [dev, db]. All writers get this context map."
+  type        = "list"
+}
+
+resource "aws_iam_role_policy_attachment" "credstash-writer-policy-attachment" {
+  count      = "${var.role_count}"
+  role       = "${var.role_names[count.index]}"
+  policy_arn = "${var.writer_policy_arn}"
+}
+
+resource "aws_kms_grant" "credstash-writer" {
+  count             = "${var.role_count}"
+  name              = "${var.role_names[count.index]}-credstash-writer"
+  grantee_principal = "${var.role_arns[count.index]}"
+  key_id            = "${var.kms_key_arn}"
+  operations        = ["GenerateDataKey"]
+
+  constraints {
+    encryption_context_equals = "${map(element(var.context_keys, count.index),
+                                       element(var.context_values, count.index))}"
+ }
+}


### PR DESCRIPTION
These two modules are based on the existing credstash-grant module,
but replaces the grant.sh script and local_exec provisioner that was
necessary to use in that module with the aws_kms_grant resource that
terraform now provides.

The one module is now split into two for directness in use and for
the simplicity of variables.