### PR TITLE
Bugfix: example vpn-gateway was referring to wrong path of modules.

### DIFF
--- a/examples/vpn-gateway/main.tf
+++ b/examples/vpn-gateway/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "../../vpc"
+  source = "../../modules/vpc"
 
   azs                 = ["${var.vpc_azs}"]
   cidr                = "${var.vpc_cidr}"
@@ -17,7 +17,7 @@ module "vpc" {
 }
 
 module "vpn-gateway" {
-  source = "../../vpn-gateway"
+  source = "../../modules/vpn-gateway"
 
   name_prefix        = "${var.name_prefix}"
   instance_type      = "t2.nano"


### PR DESCRIPTION
Got this when `terraform init` all examples. This example uses modules
vpc and vpn-gateway at "../../", which actually should be
"../../modules/".

Fix main.tf with correct path.