### PR TITLE
Fixup vpc-scenario-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Examples
 
+* `vpc-scenario-2`: Update for improved testing of the scenario and related modules
 * `gitlab-ha`: Update `Makefile`
 * `vpc-gateway`: correct module path reference
 * `legacy`: drop deprecated example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   * `init-snippet-nomad-agent`
   * `init-snippet-prometheus`
   * `init-snippet-write-bootstrap-pillar`
+* `vpc-scenario-2`: minor bugfix for NAT count
 
 [1]: https://github.com/terraform-providers/terraform-provider-template/blob/master/CHANGELOG.md#200-january-14-2019
 

--- a/examples/vpc-scenario-2/Makefile
+++ b/examples/vpc-scenario-2/Makefile
@@ -47,6 +47,23 @@ apply: check-plan-file
 test:
 	@curl -v http://$$(terraform output elb_dns)/
 
+## Use ops http polling to block until ELB is available, should happen in 5 minutes or less
+poll:
+	echo "will now poll that URL until we see 200 (and timeout after 5 minutes)"
+	ops http poll --interval 5 --retry 60 http://$(shell terraform output elb_dns)/
+
+## use existing targets to run it all (hopefully)
+all: ssh-key init plan-subnets apply plan-gateways apply plan apply poll
+
+## Use ops to lookup IPs of the EC2 nodes in the ASG
+lookup-ips:
+	ops aws ec2 asg ips --region $(shell terraform output region) --private $(shell terraform output asg_name)
+
+## Use ops to terminate all of the EC2 nodes in the ASG
+terminate-ec2-nodes:
+	ops aws ec2 asg terminate --region $(shell terraform output region) $(shell terraform output asg_name)
+
+
 ## terraform destroy everything
 destroy:
 	@terraform destroy

--- a/examples/vpc-scenario-2/README.md
+++ b/examples/vpc-scenario-2/README.md
@@ -14,17 +14,37 @@ make plan-gateways
 make apply
 make plan
 make apply
+make poll
 ```
+
+Or, alternatively, use `make all`.
 
 ## Testing
 
-Get the public IP address of the newly created ec2 web instance with the AWS console.
+Use `make poll` to hit the ELB until we see an HTTP 200 (or until the 5 minute timeout).
 
-SSH into the machine with the command:
+## Bastion
+
+If your SSH key is the default from the example (`./id_rsa`), write a `ssh_config` like:
 
 ```
-ssh -i id_rsa ubuntu@<vpc-ip-address>
+Host bastion
+    HostName      ${BASTION_IP_TO_UPDATE}
+    User          ubuntu
+    IdentityFile  ./id_rsa
+
+
+Host 10.23.*
+    User            ubuntu
+    IdentityFile    ./id_rsa
+    ProxyCommand    ssh -F ssh_config bastion -W %h:%p
+    StrictHostKeyChecking ask
 ```
+
+Then get the private IP addresses of the web servers in the private subnets with
+`make lookup-ips`.
+
+Then `ssh -F ssh_config $IP`.
 
 ## Destruction
 
@@ -37,5 +57,5 @@ make clean
 
 ## Notes
 
-* This example was last tested with `Terraform v0.11.7`
+* This example was last tested with `Terraform v0.11.13`
 * This example assumes AWS credentials setup with access to the **us-east-2** region.

--- a/examples/vpc-scenario-2/bastion.tf
+++ b/examples/vpc-scenario-2/bastion.tf
@@ -1,0 +1,52 @@
+resource "aws_instance" "bastion" {
+  ami                         = "${module.ubuntu-xenial-ami.id}"
+  associate_public_ip_address = "true"
+  instance_type               = "t2.nano"
+  key_name                    = "${aws_key_pair.main.key_name}"
+  subnet_id                   = "${module.vpc.public_subnet_ids[0]}"
+  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "20"
+  }
+
+  lifecycle = {
+    ignore_changes = ["ami", "user_data"]
+  }
+
+  user_data = <<END_INIT
+#!/bin/bash
+echo "hello init"
+END_INIT
+}
+
+# Security group for the bastion instance
+resource "aws_security_group" "bastion" {
+  name   = "${var.name}-bastion"
+  vpc_id = "${module.vpc.vpc_id}"
+}
+
+module "bastion-ssh-rule" {
+  source            = "../../modules/ssh-sg"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+# open egress for bastion instance (outbound from the node)
+module "bastion-egress-rule" {
+  source            = "../../modules/open-egress-sg"
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+# EIP for the bastion instance
+resource "aws_eip" "bastion" {
+  vpc   = "true"
+}
+
+# Attach the EIP to the bastion instance
+resource "aws_eip_association" "bastion" {
+  allocation_id = "${aws_eip.bastion.id}"
+  instance_id   = "${aws_instance.bastion.id}"
+}
+

--- a/modules/vpc-scenario-2/main.tf
+++ b/modules/vpc-scenario-2/main.tf
@@ -78,7 +78,7 @@ module "nat-gateway" {
   source             = "../nat-gateways"
   vpc_id             = "${module.vpc.vpc_id}"
   name_prefix        = "${var.name_prefix}"
-  nat_count          = "${length(var.private_subnet_cidrs)}"
+  nat_count          = "${length(var.public_subnet_cidrs)}"
   public_subnet_ids  = ["${module.public-subnets.ids}"]
   private_subnet_ids = ["${module.private-subnets.ids}"]
   extra_tags         = "${merge(


### PR DESCRIPTION
    examples/vpc-scenario-2: update to make it more useful
    
    * bump Ubuntu web instance to 16.04
    * use the simple-hostname init-snippet to include tests for more modules
    * update init to better use our modules
    * add a bastion instance
    * update security groups for the web/bastion so SSH tunneling through
      the bastion works as expected
    * add some outputs to make it easier
    * add new make targets in the Makefile, to lookup-ips, terminate
      instances, and poll for HTTP success - easier testing
