### PR TITLE
Added alb_target_group_arns parameter to attach an Application load balancer in the ASG module

### DIFF
--- a/modules/asg/README.md
+++ b/modules/asg/README.md
@@ -7,6 +7,7 @@ The module supports:
 
 * spanning N Availability Zones
 * load balancers may be associated with the ASG
+* Application load balancer defining the variable alb_target_group_arn
 * the health checks are not yet parametized, (easy to change)
 * the Launch Configuration supports an arbitrary list of security groups
 * `lifecycle` and `create_before_destroy` are used to ensure updates are graceful

--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -30,6 +30,7 @@ resource "aws_autoscaling_group" "cluster" {
   health_check_type         = "EC2"
   launch_configuration      = aws_launch_configuration.cluster.name
   load_balancers            = var.elb_names
+  target_group_arns         = var.alb_target_group_arns
   max_size                  = var.max_nodes
   min_size                  = var.min_nodes
   name_prefix               = "${var.name_prefix}-${var.name_suffix}"

--- a/modules/asg/variables.tf
+++ b/modules/asg/variables.tf
@@ -80,6 +80,12 @@ variable "elb_names" {
   type        = list(string)
 }
 
+variable "alb_target_group_arns" {
+  default     = []
+  description = "list of target_group for application load balancer to associate with the ASG (by ARN)"
+  type        = list(string)
+}
+
 variable "root_volume_type" {
   default     = "gp2"
   description = "The type of EBS volume to use for the root block device"


### PR DESCRIPTION
This is a small change for the ASG module that adds the `alb_target_group_arns` parameter to let the module the possibility to attach the ASG to an Application load balancer.


- [ ] Update the changelog
- [x] Make sure that modules and files are documented. This can be done inside the module and files.
- [x] Make sure that new modules directories contain a basic README.md file.
- [x] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [x] Make sure that the linting passes on CI.
- [x] Make sure that there is an up to date example for your code:
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.


### output
 ```
$make plan

Terraform will perform the following actions:                                                                                                  
                                                                                                                                               
  # module.main.module.web.aws_autoscaling_group.cluster will be created                                                                       
  + resource "aws_autoscaling_group" "cluster" {                                                                                               
      + arn                       = (known after apply)
      + availability_zones        = (known after
      + default_cooldown          = (known after apply)
      + desired_capacity          = (known after apply)
      + force_delete              = true
      + health_check_grace_period = 300
      + health_check_type         = "EC2"
      + id                        = (known after apply)
      + launch_configuration      = "terraform-xxxxxxxxxxx"
      + load_balancers            = (known after apply) 
      + max_size                  = 3 
      + metrics_granularity       = "1Minute" 
      + min_size                  = 3
      + name                      = "dev-web-cluster"
      + protect_from_scale_in     = false
      + service_linked_role_arn   = (known after apply)            
      + tags                      = [                                                                                                          
          + {
              + "key"                 = "Name"
              + "propagate_at_launch" = "true"
              + "value"               = "consumer-env-dev-web-cluster"
            },
        ]
      + target_group_arns         = [
          + "arn:aws:elasticloadbalancing:us-west-2:xxxxxxxxxx:targetgroup/tf-xxxxx/xxxxxxxxxx",
        ]
      + termination_policies      = []
      + vpc_zone_identifier       = [
          + "subnet-xxxxxxx",
          + "subnet-xxxxxxx",
          + "subnet-xxxxxxx",
        ]
      + wait_for_capacity_timeout = "10m"
          }

Plan: 1 to add, 0 to change, 0 to destroy.
```
```
$ make apply
terraform-0.12.2 apply -parallelism=7 tf.out
module.main.module.web.aws_autoscaling_group.cluster: Creating...
module.main.module.web.aws_autoscaling_group.cluster: Still creating... [10s elapsed]
module.main.module.web.aws_autoscaling_group.cluster: Still creating... [20s elapsed]
module.main.module.web.aws_autoscaling_group.cluster: Still creating... [30s elapsed]
module.main.module.web.aws_autoscaling_group.cluster: Still creating... [40s elapsed]
module.main.module.web.aws_autoscaling_group.cluster: Still creating... [50s elapsed]
module.main.module.web.aws_autoscaling_group.cluster: Creation complete after 51s [id=dev-web-cluster]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

@ketzacoatl no sure if this test shows that the PR is ready to merge with the 0.12 branch