### PR TITLE
New module ami-centos. Fixes #218.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 * `single-port-sg`: Add support for UDP rules
 * `kube-controller-sg`: Update to sync with `single-port-sg` module
+* `ami-centos`: simple module to get the ami id of the specified release of CentOS.
 
 ### Examples
-
+* `ami-centos-test`: New testing example for `ami-centos`.
 
 # v0.8.3
 

--- a/examples/ami-centos-test/tester.tf
+++ b/examples/ami-centos-test/tester.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  region = "us-west-1"
+}
+
+module "ami" {
+  source  = "../../modules/ami-centos"
+  release = "7"
+}
+
+resource "aws_instance" "test" {
+  ami             = "${module.ami.id}"
+  instance_type   = "t2.micro"
+  key_name        = "shida-west-1"
+  security_groups = ["ssh_only"]
+}
+
+resource "aws_security_group" "ssh_only" {
+  name = "ssh_only"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+output "ip" {
+  value = "${aws_instance.test.public_ip}"
+}

--- a/modules/ami-centos/README.md
+++ b/modules/ami-centos/README.md
@@ -1,0 +1,35 @@
+## Centos AMI lookup helper
+
+This module is a simple helper that looks up the current AMI ID for a given
+release of Centos. Use it like:
+
+```
+module "centos-7-ami" {
+  source  = "../../modules/ami-centos"
+}
+```
+
+Or:
+
+```
+module "centos-6-ami" {
+  source  = "../../modules/ami-centos"
+  release = "6"
+}
+```
+
+To use the AMI on EC2, reference it by ID like this: `${module.centos-7-ami.id}`
+
+The module will filter the AMI by the following criteria:
+
+* provided by Centos.org
+* the most recent release
+* hvm-type AMIs
+* amd64
+* release
+
+If you deploy an instance with this AMI, and later do a `terraform plan`, the
+most recent AMI will be looked up, and that may change the module output, and
+then the AMI for the instance. You can use `ignore_changes` or `-target`, to
+work around that situation, or take that as your reminder to replace the
+instance with a more recent release of the upstream AMI.

--- a/modules/ami-centos/main.tf
+++ b/modules/ami-centos/main.tf
@@ -1,0 +1,33 @@
+variable "most_recent" {
+  default     = "true"
+  description = "boolean, maps to `most_recent` parameter for `aws_ami` data source"
+  type        = "string"
+}
+
+variable "release" {
+  description = "default centos release to target"
+  type        = "string"
+}
+
+data "aws_ami" "centos" {
+  most_recent = "${var.most_recent}"
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["679593333241"]
+
+  name_regex = "^CentOS Linux ${var.release} x86_64 HVM EBS ENA"
+}
+
+output "id" {
+  value       = "${data.aws_ami.centos.id}"
+  description = "ID of the AMI"
+}


### PR DESCRIPTION
Add a new module to lookup the CentOS AMI we want.

- [x] Update the changelog
- [x] Make sure that modules and files are documented. This can be done inside the module and files.
- [x] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [x] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.