### PR TITLE
tests: disable v0.12.x modules until we merge v0.12 branch

### DIFF
--- a/tests/main.tf
+++ b/tests/main.tf
@@ -293,16 +293,16 @@ module "ha-management-cluster" {
   worker_cidr_blocks = []
 }
 
-module "iam-group" {
-  source     = "../modules/iam-group"
-  group_name = ""
-  members    = []
-}
+#module "iam-group" {
+#  source     = "../modules/iam-group"
+#  group_name = ""
+#  members    = []
+#}
 
-module "iam-users" {
-  source    = "../modules/iam-users"
-  user_list = []
-}
+#module "iam-users" {
+#  source    = "../modules/iam-users"
+#  user_list = []
+#}
 
 module "init-snippet-attach-ebs-volume" {
   source = "../modules/init-snippet-attach-ebs-volume"


### PR DESCRIPTION
There are 2 modules that are for v0.12.x only, but they were merged to master a little early. That's ok, but they are making the tf linting fail (as that is focusing on v0.11 syntax). These will be re-enabled after the v0.12.x branch is merged.