### PR TITLE
New: module autoscaling-policy-metric-alarm-pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # (Unreleased)
 
+### Modules
+
+* `autoscaling-policy-metric-alarm-pair`: New module abstracts the autoscaling function from example load-asg. The example now is using this module.
+
 # v0.9.0
 
 ### Summary

--- a/examples/load-asg/main.tf
+++ b/examples/load-asg/main.tf
@@ -122,8 +122,8 @@ module "web-asg" {
   name_prefix   = "${var.name}-${var.web_app_name}"
   elb_names     = [aws_elb.web.name]
   instance_type = var.instance_type
-  max_nodes     = "10"
-  min_nodes     = "2"
+  max_nodes     = 10
+  min_nodes     = 2
   public_ip     = false
   key_name      = aws_key_pair.main.key_name
   subnet_ids    = module.vpc.public_subnet_ids
@@ -167,108 +167,17 @@ END_INIT
 
 }
 
-## Autoscaling Policies
-
-# ASG Policy Up
-
-resource "aws_autoscaling_policy" "cpu_up" {
-  name                   = "${var.name}-asg-policy-cpu-up"
-  autoscaling_group_name = module.web-asg.name
-  adjustment_type        = "ChangeInCapacity"
-  cooldown               = 300
-  scaling_adjustment     = 3
-  policy_type            = "SimpleScaling"
+module "web_cpu_autoscaling" {
+  source = "../../modules/autoscaling-policy-metric-alarm-pair"
+  name = var.name
+  asg_name = module.web-asg.name
+  metric = "CPUUtilization"
 }
 
-resource "aws_autoscaling_policy" "mem_up" {
-  name                   = "${var.name}-asg-policy-mem-up"
-  autoscaling_group_name = module.web-asg.name
-  adjustment_type        = "ChangeInCapacity"
-  cooldown               = 300
-  scaling_adjustment     = 3
-  policy_type            = "SimpleScaling"
-}
-
-# Cloudwatch Monitor CPU Up
-resource "aws_cloudwatch_metric_alarm" "web_cpu_scale_up" {
-  alarm_name          = "${var.name}-cpu-scale-up-alarm"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "60"
-  dimensions = {
-    AutoScalingGroupName = module.web-asg.name
-  }
-  alarm_actions = [aws_autoscaling_policy.cpu_up.arn]
-}
-
-# Cloudwatch Monitor Memory Up
-resource "aws_cloudwatch_metric_alarm" "web_mem_scale_up" {
-  alarm_name          = "${var.name}-mem-scale-up-alarm"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
-  metric_name         = "MemoryUtilization"
-  namespace           = "AWS/EC2"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "60"
-  dimensions = {
-    AutoScalingGroupName = module.web-asg.name
-  }
-  alarm_actions = [aws_autoscaling_policy.mem_up.arn]
-}
-
-# ASG Policy Down
-resource "aws_autoscaling_policy" "cpu_down" {
-  name                   = "${var.name}-asg-policy-cpu-down"
-  autoscaling_group_name = module.web-asg.name
-  adjustment_type        = "ChangeInCapacity"
-  cooldown               = 300
-  scaling_adjustment     = -2
-  policy_type            = "SimpleScaling"
-}
-
-resource "aws_autoscaling_policy" "mem_down" {
-  name                   = "${var.name}-asg-policy-mem-down"
-  autoscaling_group_name = module.web-asg.name
-  adjustment_type        = "ChangeInCapacity"
-  cooldown               = 300
-  scaling_adjustment     = -2
-  policy_type            = "SimpleScaling"
-}
-
-# Cloudwatch CPU Monitor Down
-resource "aws_cloudwatch_metric_alarm" "web_cpu_scale_down" {
-  alarm_name          = "${var.name}-cpu-scale-down-alarm"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "3"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "30"
-  dimensions = {
-    AutoScalingGroupName = module.web-asg.name
-  }
-  alarm_actions = [aws_autoscaling_policy.cpu_down.arn]
-}
-
-# Cloudwatch Memory Monitor Down
-resource "aws_cloudwatch_metric_alarm" "web_mem_scale_down" {
-  alarm_name          = "${var.name}-mem-scale-down-alarm"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "3"
-  metric_name         = "MemoryUtilization"
-  namespace           = "AWS/EC2"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "30"
-  dimensions = {
-    AutoScalingGroupName = module.web-asg.name
-  }
-  alarm_actions = [aws_autoscaling_policy.mem_down.arn]
+module "web_mem_autoscaling" {
+  source = "../../modules/autoscaling-policy-metric-alarm-pair"
+  name = var.name
+  asg_name = module.web-asg.name
+  metric = "MemoryUtilization"
 }
 

--- a/modules/autoscaling-policy-metric-alarm-pair/main.tf
+++ b/modules/autoscaling-policy-metric-alarm-pair/main.tf
@@ -1,0 +1,123 @@
+variable "name" {
+  description = "Prefix of the AutoScaling Policy."
+  type = string
+}
+
+variable "asg_name" {
+  description = "Name of the AutoScaling Group that this policy would apply to."
+  type = string
+}
+
+variable "metric" {
+  description = "CPUUtilization or MemoryUtilization"
+  type = string
+}
+
+variable "up_evaluation_periods" {
+  default     = 3
+  description = ""
+  type = number
+}
+
+variable "up_period" {
+  default     = 60
+  description = ""
+  type = number
+}
+
+variable "up_threshold" {
+  default     = 60
+  description = ""
+  type = number
+}
+
+variable "up_scaling_adjustment" {
+  default     = 3
+  description = ""
+  type = number
+}
+
+variable "up_cooldown" {
+  default     = 300
+  description = ""
+  type = number
+}
+
+variable "down_evaluation_periods" {
+  default     = 3
+  description = ""
+  type = number
+}
+
+variable "down_period" {
+  default     = 60
+  description = ""
+  type = number
+}
+
+variable "down_threshold" {
+  default     = 30
+  description = ""
+  type = number
+}
+
+variable "down_scaling_adjustment" {
+  default     = 2
+  description = ""
+  type = number
+}
+
+variable "down_cooldown" {
+  default     = 300
+  description = ""
+  type = number
+}
+
+resource "aws_autoscaling_policy" "scale_up" {
+  name                   = "${var.name}-asp-up"
+  autoscaling_group_name = var.asg_name
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = var.up_cooldown
+  scaling_adjustment     = var.up_scaling_adjustment
+  policy_type            = "SimpleScaling"
+}
+
+resource "aws_cloudwatch_metric_alarm" "scale_up" {
+  alarm_name          = "${var.name}-scale-up-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = var.up_evaluation_periods
+  metric_name         = var.metric
+  namespace           = "AWS/EC2"
+  period              = var.up_period
+  statistic           = "Average"
+  threshold           = var.up_threshold
+  dimensions = {
+    AutoScalingGroupName = var.asg_name
+  }
+  alarm_actions = [aws_autoscaling_policy.scale_up.arn]
+}
+
+resource "aws_autoscaling_policy" "scale_down" {
+  name                   = "${var.name}-asp-down"
+  autoscaling_group_name = var.asg_name
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = var.down_cooldown
+  scaling_adjustment     = "-${var.down_scaling_adjustment}"
+  policy_type            = "SimpleScaling"
+}
+
+resource "aws_cloudwatch_metric_alarm" "scale_down" {
+  alarm_name          = "${var.name}-scale-down-alarm"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = var.down_evaluation_periods
+  metric_name         = var.metric
+  namespace           = "AWS/EC2"
+  period              = var.down_period
+  statistic           = "Average"
+  threshold           = var.down_threshold
+  dimensions = {
+    AutoScalingGroupName = var.asg_name
+  }
+  alarm_actions = [aws_autoscaling_policy.scale_down.arn]
+}
+

--- a/modules/autoscaling-policy-metric-alarm-pair/versions.tf
+++ b/modules/autoscaling-policy-metric-alarm-pair/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Abstract usage of autoscaling policy and cloudwatch alarm to autoscale
ASG.

By moving the code from load-asg example. Example load-asg is using the
new module now.

Fixes #195 .

---
name: Pull request template
about: Make a PR to terraform-aws-foundation
---

Please include the following in your PR:

Please also note that these are not hard requirements, but merely serve to define
what maintainers are looking for in PR's.  Including these will more likely lead 
to your PR being reviewed and accepted.

- [ ] Update the changelog
- [ ] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.