### PR TITLE
Vpc scenario 2 with an Application Load Balancer

### DIFF
--- a/examples/vpc-scenario-2-alb/Makefile
+++ b/examples/vpc-scenario-2-alb/Makefile
@@ -1,0 +1,100 @@
+.PHONY: ssh-key init plan-subnets plan-gateways plan apply test destroy clean
+
+.DEFAULT_GOAL = help
+
+# Hardcoding value of 3 minutes when we check if the plan file is stale
+STALE_PLAN_FILE := `find "tf.out" -mmin -3 | grep -q tf.out`
+
+## Check if tf.out is stale (Older than 2 minutes)
+check-plan-file:
+	@if ! ${STALE_PLAN_FILE} ; then \
+		echo "ERROR: Stale tf.out plan file (older than 3 minutes)!"; \
+		exit 1; \
+	fi
+
+## Create ssh key
+ssh-key:
+	@ssh-keygen -q -N "" -b 4096 -C "SSH key for vpc-scenario-2 example" -f ./id_rsa
+
+## Runs terraform get and terraform init for env
+init:
+	@terraform get
+	@terraform init
+
+## use 'terraform plan' to 'target' the public/private subnets in the vpc module
+plan-subnets:
+	@terraform plan \
+		-target="module.vpc.module.public-subnets" \
+		-target="module.vpc.module.private-subnets" \
+		-out=tf.out
+
+## use 'terraform plan' to 'target' the public and NAT gateways in the vpc module
+plan-gateways:
+	@terraform plan \
+		-target="module.vpc.module.public-gateway" \
+		-target="module.vpc.module.nat-gateway" \
+		-out=tf.out
+
+## terraform plan (makes everything)
+plan:
+	@terraform plan -out=tf.out
+
+## terraform apply
+apply: check-plan-file
+	@terraform apply tf.out
+
+## use curl to hit the ELB to confirm the VPC came online ok
+test:
+	@curl -v http://$$(terraform output alb_dns)/
+
+## Use ops http polling to block until ELB is available, should happen in 5 minutes or less
+poll:
+	echo "will now poll that URL until we see 200 (and timeout after 5 minutes)"
+	ops http poll --interval 5 --retry 60 http://$(shell terraform output elb_dns)/
+
+## use existing targets to run it all (hopefully)
+all:
+	$(MAKE) ssh-key
+	$(MAKE) init
+	$(MAKE) plan-subnets
+	$(MAKE) apply
+	$(MAKE) plan-gateways
+	$(MAKE) apply
+	$(MAKE) plan
+	$(MAKE) apply
+	$(MAKE) poll
+
+## Use ops to lookup IPs of the EC2 nodes in the ASG
+lookup-ips:
+	ops aws ec2 asg ips --region $(shell terraform output region) --private $(shell terraform output asg_name)
+
+## Use ops to terminate all of the EC2 nodes in the ASG
+terminate-ec2-nodes:
+	ops aws ec2 asg terminate --region $(shell terraform output region) $(shell terraform output asg_name)
+
+
+## terraform destroy everything
+destroy:
+	@terraform destroy
+
+## rm -rf all files and state
+clean:
+	@rm -f tf.out
+	@rm -f id_rsa
+	@rm -f id_rsa.pub
+	@rm -f terraform.tfvars
+	@rm -f terraform.*.backup
+	@rm -f terraform.tfstate
+
+## Show help screen.
+help:
+	@echo "Please use \`make <target>' where <target> is one of\n\n"
+	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")-1); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "%-30s %s\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)

--- a/examples/vpc-scenario-2-alb/README.md
+++ b/examples/vpc-scenario-2-alb/README.md
@@ -1,0 +1,61 @@
+# Example to test the VPC Scenario 2 Module with an Application Load Balancer
+
+## Environment creation and deployment
+
+To use this example set up AWS credentials and then run the commands in the 
+following order:
+
+```
+make ssh-key
+make init
+make plan-subnets
+make apply
+make plan-gateways
+make apply
+make plan
+make apply
+make poll
+```
+
+Or, alternatively, use `make all`.
+
+## Testing
+
+Use `make poll` to hit the ELB until we see an HTTP 200 (or until the 5 minute timeout).
+
+## Bastion
+
+If your SSH key is the default from the example (`./id_rsa`), write a `ssh_config` like:
+
+```
+Host bastion
+    HostName      ${BASTION_IP_TO_UPDATE}
+    User          ubuntu
+    IdentityFile  ./id_rsa
+
+
+Host 10.23.*
+    User            ubuntu
+    IdentityFile    ./id_rsa
+    ProxyCommand    ssh -F ssh_config bastion -W %h:%p
+    StrictHostKeyChecking ask
+```
+
+Then get the private IP addresses of the web servers in the private subnets with
+`make lookup-ips`.
+
+Then `ssh -F ssh_config $IP`.
+
+## Destruction
+
+To destroy the test environment run the following commands:
+
+```
+make destroy
+make clean
+```
+
+## Notes
+
+* This example was last tested with `Terraform v0.11.13`
+* This example assumes AWS credentials setup with access to the **us-east-2** region.

--- a/examples/vpc-scenario-2-alb/bastion.tf
+++ b/examples/vpc-scenario-2-alb/bastion.tf
@@ -1,0 +1,48 @@
+resource "aws_instance" "bastion" {
+  ami                         = "${module.ubuntu-xenial-ami.id}"
+  associate_public_ip_address = "true"
+  instance_type               = "t2.nano"
+  key_name                    = "${aws_key_pair.main.key_name}"
+  subnet_id                   = "${module.vpc.public_subnet_ids[0]}"
+  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "20"
+  }
+
+  user_data = <<END_INIT
+#!/bin/bash
+echo "hello init"
+END_INIT
+}
+
+# Security group for the bastion instance
+resource "aws_security_group" "bastion" {
+  name   = "${var.name}-bastion"
+  vpc_id = "${module.vpc.vpc_id}"
+}
+
+module "bastion-ssh-rule" {
+  source            = "../../modules/ssh-sg"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+# open egress for bastion instance (outbound from the node)
+module "bastion-egress-rule" {
+  source            = "../../modules/open-egress-sg"
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+# EIP for the bastion instance
+resource "aws_eip" "bastion" {
+  vpc   = "true"
+}
+
+# Attach the EIP to the bastion instance
+resource "aws_eip_association" "bastion" {
+  allocation_id = "${aws_eip.bastion.id}"
+  instance_id   = "${aws_instance.bastion.id}"
+}
+

--- a/examples/vpc-scenario-2-alb/main.tf
+++ b/examples/vpc-scenario-2-alb/main.tf
@@ -1,0 +1,287 @@
+/**
+ * ## Run Tests on the VPC Scenario 2 Module
+ *
+ *
+ */
+
+variable "extra_tags" {
+  description = "Extra tags that will be added to aws_subnet resources"
+  default     = {}
+}
+
+variable "name" {
+  description = "name of the project, use as prefix to names of resources created"
+  default     = "pm-vpc-2-alb"
+}
+
+variable "region" {
+  description = "Region where the project will be deployed"
+  default     = "eu-west-1"
+}
+
+variable "vpc_cidr" {
+  description = "Top-level CIDR for the whole VPC network space"
+  default     = "10.23.0.0/16"
+}
+
+variable "ssh_pubkey" {
+  description = "File path to SSH public key"
+  default     = "./id_rsa.pub"
+}
+
+variable "ssh_key" {
+  description = "File path to SSH public key"
+  default     = "./id_rsa"
+}
+
+variable "public_subnet_cidrs" {
+  default     = ["10.23.11.0/24", "10.23.12.0/24", "10.23.13.0/24"]
+  description = "A list of public subnet CIDRs to deploy inside the VPC"
+}
+
+variable "private_subnet_cidrs" {
+  default     = ["10.23.21.0/24", "10.23.22.0/24", "10.23.23.0/24"]
+  description = "A list of private subnet CIDRs to deploy inside the VPC"
+}
+
+variable "alb_security_group_ids" {
+  default     = []
+  description = "Extra security groups to attach in the ALB"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_availability_zones" "available" {
+}
+
+module "vpc" {
+  source      = "../../modules/vpc-scenario-2"
+  name_prefix = var.name
+  region      = var.region
+  cidr        = var.vpc_cidr
+  azs         = local.azs
+
+  extra_tags = {
+    kali = "ma"
+  }
+
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+}
+
+module "ubuntu-xenial-ami" {
+  source  = "../../modules/ami-ubuntu"
+  release = "18.04"
+}
+
+resource "aws_key_pair" "main" {
+  key_name   = var.name
+  public_key = file(var.ssh_pubkey)
+}
+
+# Security group for the elastic load balancer
+module "alb-sg" {
+  source      = "../../modules/security-group-base"
+  description = "Allow public access to ALB in ${var.name}"
+  name        = "${var.name}-alb"
+  vpc_id      = module.vpc.vpc_id
+}
+
+# security group rule for elb open inbound http
+module "alb-http-rule" {
+  source            = "../../modules/single-port-sg"
+  port              = 80
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.alb-sg.id
+  description       = "open HTTP on the ALB to public access"
+}
+
+# security group rule for elb open egress (outbound from nodes)
+module "alb-open-egress-rule" {
+  source            = "../../modules/open-egress-sg"
+  security_group_id = module.alb-sg.id
+}
+
+# Security group for the web instance, only accessible from ALB
+module "web-sg" {
+  source      = "../../modules/security-group-base"
+  description = "Allow HTTP and SSH to web instance in ${var.name}"
+  name        = "${var.name}-web"
+  vpc_id      = module.vpc.vpc_id
+}
+
+# allow HTTP from ELB to web instances
+module "web-http-elb-sg-rule" {
+  source            = "../../modules/single-port-sg"
+  port              = "3000"
+  description       = "Allow ELB HTTP to web app on port 3000"
+  cidr_blocks       = module.vpc.public_cidr_blocks
+  security_group_id = module.web-sg.id
+}
+
+# allow SSH from bastion in public subnets to web instances
+module "web-ssh-rule" {
+  source            = "../../modules/ssh-sg"
+  cidr_blocks       = module.vpc.public_cidr_blocks #["0.0.0.0/0"] #
+  security_group_id = "${module.web-sg.id}"
+}
+
+# open egress for web instances (outbound from nodes)
+module "web-open-egress-sg-rule" {
+  source            = "../../modules/open-egress-sg"
+  security_group_id = module.web-sg.id
+}
+
+
+## Load Balancer
+# Application Load Balancer
+resource "aws_lb" "web" {
+  name               = "${var.name}-alb"
+  idle_timeout       = "300"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = concat(var.alb_security_group_ids, list(module.alb-sg.id))
+  subnets            = module.vpc.public_subnet_ids
+
+  tags =  merge(
+            map("Name", "${var.name}-alb"),
+            "${var.extra_tags}"
+          )
+
+# TODO: setup S3 to upload logs
+#  access_logs {
+#    bucket  = "${var.access_log_bucket_name}"
+#    enabled = true
+#    prefix  = "${var.name}-alb"
+#  }
+}
+
+# ALB Target group for the service running
+resource "aws_lb_target_group" "alb_target_group" {
+  port     = "3000"
+  protocol = "HTTP"
+  vpc_id   = module.vpc.vpc_id
+
+  tags = merge(
+          map("Name", "${var.name}-alb-tg"),
+          "${var.extra_tags}"
+         )
+
+  health_check {
+    protocol = "HTTP"
+    matcher  = "200"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  stickiness {
+    type    = "lb_cookie"
+    enabled = false
+  }
+}
+
+# External HTTP listener on port 80 to attach the ALB
+resource "aws_lb_listener" "external-http" {
+  load_balancer_arn = aws_lb.web.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alb_target_group.arn
+  }
+}
+
+module "web" {
+  source                  = "../../modules/asg"
+  ami                     = module.ubuntu-xenial-ami.id
+  azs                     = local.azs
+  name_prefix             = "${var.name}-web"
+  alb_target_group_arns   = [aws_lb_target_group.alb_target_group.arn]
+  instance_type           = "t2.nano"
+  max_nodes               = length(module.vpc.public_subnet_ids)
+  min_nodes               = length(module.vpc.public_subnet_ids)
+  public_ip               = false
+  key_name                = aws_key_pair.main.key_name
+  subnet_ids              = module.vpc.private_subnet_ids
+
+  security_group_ids = [module.web-sg.id]
+
+  root_volume_type = "gp2"
+  root_volume_size = "8"
+
+  user_data = <<END_INIT
+#!/bin/bash
+${module.init-simple-hostname.init_snippet}
+${module.init-warp-hello-world.init_snippet}
+END_INIT
+}
+
+module "init-simple-hostname" {
+  source = "../../modules/init-snippet-hostname-simple"
+
+  hostname_prefix = "web"
+}
+
+
+module "init-warp-hello-world" {
+  source = "../../modules/init-snippet-exec"
+
+  init = <<END_INIT
+echo "hello!"
+apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable"
+apt-get update
+apt-get install -y docker-ce
+
+docker run                   \
+    --restart=always         \
+    -d                       \
+    -v /var/log/cloud-init-output.log:/var/www/html/cloud-init-output.log \
+    -p $(ec2metadata --local-ipv4):3000:3000 \
+    yesodweb/warp            \
+    warp --docroot /var/www/html
+END_INIT
+
+}
+
+locals {
+  alb_logs_bucket_name = "${var.name}-alb-logs"
+  az_count = length(var.public_subnet_cidrs)
+  azs = slice(
+    data.aws_availability_zones.available.names,
+    0,
+    local.az_count)
+}
+
+output "alb_dns" {
+  value       = aws_lb.web.dns_name
+  description = "URL, where to find the ELB"
+}
+
+output "asg_name" {
+  value       = module.web.name
+  description = "Name of the web ASG, for looking up IP addresses"
+}
+
+output "region" {
+  value       = var.region
+  description = "Region we deployed to"
+}
+
+output "bastion_eip" {
+  value       = aws_eip.bastion.public_ip
+  description = "EIP of the bastion host"
+}

--- a/examples/vpc-scenario-2-alb/versions.tf
+++ b/examples/vpc-scenario-2-alb/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/vpc-scenario-2/bastion.tf
+++ b/examples/vpc-scenario-2/bastion.tf
@@ -11,10 +11,6 @@ resource "aws_instance" "bastion" {
     volume_size = "20"
   }
 
-  lifecycle = {
-    ignore_changes = ["ami", "user_data"]
-  }
-
   user_data = <<END_INIT
 #!/bin/bash
 echo "hello init"

--- a/examples/vpc-scenario-2/main.tf
+++ b/examples/vpc-scenario-2/main.tf
@@ -16,7 +16,7 @@ variable "name" {
 
 variable "region" {
   description = "Region where the project will be deployed"
-  default     = "us-east-2"
+  default     = "us-west-2"
 }
 
 variable "vpc_cidr" {
@@ -119,8 +119,8 @@ module "web-http-elb-sg-rule" {
 # allow SSH from bastion in public subnets to web instances
 module "web-ssh-rule" {
   source            = "../../modules/ssh-sg"
-  cidr_blocks       = ["${module.vpc.public_cidr_blocks}"] #["0.0.0.0/0"] #
-  security_group_id = "${module.web-sg.id}"
+  cidr_blocks       = module.vpc.public_cidr_blocks #["0.0.0.0/0"] #
+  security_group_id = module.web-sg.id
 }
 
 # open egress for web instances (outbound from nodes)


### PR DESCRIPTION
This example adds a similar environment than the VPC scenario 2 but instead of deploying an Elastic/classic Load Balancer creates an Application Load Balancer

- [ ] Update the changelog
- [x] Make sure that modules and files are documented. This can be done inside the module and files.
- [x] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [x] Make sure that the linting passes on CI.
- [x] Make sure that there is an up to date example for your code:
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [x] Make sure that there is a manual CI trigger that can test the deployment.
