### PR TITLE
Bugfix: Something missed in the major 0.12 upgrade.

### DIFF
--- a/examples/vpc-scenario-2/Makefile
+++ b/examples/vpc-scenario-2/Makefile
@@ -1,6 +1,10 @@
+MAKEOPTS = -s
+
 .PHONY: ssh-key init plan-subnets plan-gateways plan apply test destroy clean
 
 .DEFAULT_GOAL = help
+
+export TERRAFORM = terraform-0.12.4
 
 # Hardcoding value of 3 minutes when we check if the plan file is stale
 STALE_PLAN_FILE := `find "tf.out" -mmin -3 | grep -q tf.out`
@@ -14,38 +18,38 @@ check-plan-file:
 
 ## Create ssh key
 ssh-key:
-	@ssh-keygen -q -N "" -b 4096 -C "SSH key for vpc-scenario-2 example" -f ./id_rsa
+	ssh-keygen -q -N "" -b 4096 -C "SSH key for vpc-scenario-2 example" -f ./id_rsa
 
 ## Runs terraform get and terraform init for env
 init:
-	@terraform get
-	@terraform init
+	$(TERRAFORM) get
+	$(TERRAFORM) init
 
 ## use 'terraform plan' to 'target' the public/private subnets in the vpc module
 plan-subnets:
-	@terraform plan \
+	$(TERRAFORM) plan \
 		-target="module.vpc.module.public-subnets" \
 		-target="module.vpc.module.private-subnets" \
 		-out=tf.out
 
 ## use 'terraform plan' to 'target' the public and NAT gateways in the vpc module
 plan-gateways:
-	@terraform plan \
+	$(TERRAFORM) plan \
 		-target="module.vpc.module.public-gateway" \
 		-target="module.vpc.module.nat-gateway" \
 		-out=tf.out
 
 ## terraform plan (makes everything)
 plan:
-	@terraform plan -out=tf.out
+	$(TERRAFORM) plan -out=tf.out
 
 ## terraform apply
 apply: check-plan-file
-	@terraform apply tf.out
+	$(TERRAFORM) apply tf.out
 
 ## use curl to hit the ELB to confirm the VPC came online ok
 test:
-	@curl -v http://$$(terraform output elb_dns)/
+	curl -v http://$(shell $(TERRAFORM) output elb_dns)/
 
 ## Use ops http polling to block until ELB is available, should happen in 5 minutes or less
 poll:
@@ -66,25 +70,24 @@ all:
 
 ## Use ops to lookup IPs of the EC2 nodes in the ASG
 lookup-ips:
-	ops aws ec2 asg ips --region $(shell terraform output region) --private $(shell terraform output asg_name)
+	ops aws ec2 asg ips --region $(shell $(TERRAFORM) output region) --private $(shell $(TERRAFORM) output asg_name)
 
 ## Use ops to terminate all of the EC2 nodes in the ASG
 terminate-ec2-nodes:
-	ops aws ec2 asg terminate --region $(shell terraform output region) $(shell terraform output asg_name)
+	ops aws ec2 asg terminate --region $(shell $(TERRAFORM) output region) $(shell $(TERRAFORM) output asg_name)
 
 
 ## terraform destroy everything
 destroy:
-	@terraform destroy
+	$(TERRAFORM) destroy
 
 ## rm -rf all files and state
-clean:
-	@rm -f tf.out
-	@rm -f id_rsa
-	@rm -f id_rsa.pub
-	@rm -f terraform.tfvars
-	@rm -f terraform.*.backup
-	@rm -f terraform.tfstate
+clean: destroy
+	rm -f tf.out
+	rm -f id_rsa
+	rm -f id_rsa.pub
+	rm -f terraform.tfvars
+	rm -f terraform.tfstate
 
 ## Show help screen.
 help:

--- a/examples/vpc-scenario-2/bastion.tf
+++ b/examples/vpc-scenario-2/bastion.tf
@@ -1,52 +1,56 @@
 resource "aws_instance" "bastion" {
-  ami                         = "${module.ubuntu-xenial-ami.id}"
+  ami                         = module.ubuntu-xenial-ami.id
   associate_public_ip_address = "true"
   instance_type               = "t2.nano"
-  key_name                    = "${aws_key_pair.main.key_name}"
-  subnet_id                   = "${module.vpc.public_subnet_ids[0]}"
-  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+  key_name                    = aws_key_pair.main.key_name
+  subnet_id                   = module.vpc.public_subnet_ids[0]
+  vpc_security_group_ids      = [aws_security_group.bastion.id]
 
   root_block_device {
     volume_type = "gp2"
     volume_size = "20"
   }
 
-  lifecycle = {
-    ignore_changes = ["ami", "user_data"]
+  lifecycle {
+    ignore_changes = [
+      ami,
+      user_data,
+    ]
   }
 
   user_data = <<END_INIT
 #!/bin/bash
 echo "hello init"
 END_INIT
+
 }
 
 # Security group for the bastion instance
 resource "aws_security_group" "bastion" {
   name   = "${var.name}-bastion"
-  vpc_id = "${module.vpc.vpc_id}"
+  vpc_id = module.vpc.vpc_id
 }
 
 module "bastion-ssh-rule" {
-  source            = "../../modules/ssh-sg"
+  source = "../../modules/ssh-sg"
+
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 # open egress for bastion instance (outbound from the node)
 module "bastion-egress-rule" {
-  source            = "../../modules/open-egress-sg"
-  security_group_id = "${aws_security_group.bastion.id}"
+  source = "../../modules/open-egress-sg"
+  security_group_id = aws_security_group.bastion.id
 }
 
 # EIP for the bastion instance
 resource "aws_eip" "bastion" {
-  vpc   = "true"
+  vpc = "true"
 }
 
 # Attach the EIP to the bastion instance
 resource "aws_eip_association" "bastion" {
-  allocation_id = "${aws_eip.bastion.id}"
-  instance_id   = "${aws_instance.bastion.id}"
+  allocation_id = aws_eip.bastion.id
+  instance_id   = aws_instance.bastion.id
 }
-

--- a/examples/vpc-scenario-2/main.tf
+++ b/examples/vpc-scenario-2/main.tf
@@ -119,7 +119,7 @@ module "web-http-elb-sg-rule" {
 # allow SSH from bastion in public subnets to web instances
 module "web-ssh-rule" {
   source            = "../../modules/ssh-sg"
-  cidr_blocks       = ["${module.vpc.public_cidr_blocks}"] #["0.0.0.0/0"] #
+  cidr_blocks       = module.vpc.public_cidr_blocks #["0.0.0.0/0"] #
   security_group_id = "${module.web-sg.id}"
 }
 

--- a/examples/vpc-scenario-2/main.tf
+++ b/examples/vpc-scenario-2/main.tf
@@ -131,8 +131,6 @@ module "web-open-egress-sg-rule" {
 
 # Load Balancer
 resource "aws_elb" "web" {
-  name = "${var.name}-public-elb"
-
   health_check {
     healthy_threshold   = 2
     interval            = 15
@@ -159,6 +157,10 @@ resource "aws_elb" "web" {
 
   # ELBs in the public subnets, separate from the web ASG in private subnets
   subnets = module.vpc.public_subnet_ids
+
+  tags = {
+    Name = "${var.name}-public-elb"
+  }
 }
 
 module "web" {


### PR DESCRIPTION
In the VPC Scenario 2 example, we have some lingering updates to make from the v0.12.x upgrade:

* Lifecycle does not exist now.
* Drop extra `[]`
* Fixup 0.11.x syntax in `bastion.tf`
* Update the `Makefile` in the process of testing
