### PR TITLE
removed availability_zones from asg

### DIFF
--- a/examples/asg-lifecycle-hooks/main.tf
+++ b/examples/asg-lifecycle-hooks/main.tf
@@ -147,7 +147,6 @@ resource "aws_sns_topic" "main" {
 module "asg" {
   source             	  = "../../modules/asg"
   name_prefix        	  = var.name_prefix
-  azs                	  = local.azs
   elb_names          	  = [aws_elb.web.name]
   subnet_ids         	  = module.vpc.public_subnet_ids
   min_nodes          	  = 1

--- a/examples/load-asg/main.tf
+++ b/examples/load-asg/main.tf
@@ -118,7 +118,6 @@ module "ubuntu-xenial-ami" {
 module "web-asg" {
   source        = "../../modules/asg"
   ami           = module.ubuntu-xenial-ami.id
-  azs           = local.azs
   name_prefix   = "${var.name}-${var.web_app_name}"
   elb_names     = [aws_elb.web.name]
   instance_type = var.instance_type

--- a/examples/vpc-scenario-2-nat-instance/main.tf
+++ b/examples/vpc-scenario-2-nat-instance/main.tf
@@ -233,7 +233,6 @@ resource "aws_elb" "web" {
 module "web" {
   source             = "../../modules/asg"
   ami                = module.ubuntu-xenial-ami.id
-  azs                = slice(data.aws_availability_zones.available.names, 0, 3)
   name_prefix        = var.name
   name_suffix        = "webapp-server"
   elb_names          = [aws_elb.web.name]

--- a/examples/vpc-scenario-2-nat-instances-per-az/main.tf
+++ b/examples/vpc-scenario-2-nat-instances-per-az/main.tf
@@ -244,7 +244,6 @@ resource "aws_elb" "web" {
 module "web" {
   source             = "../../modules/asg"
   ami                = module.ubuntu-xenial-ami.id
-  azs                = slice(data.aws_availability_zones.available.names, 0, 3)
   name_prefix        = var.name
   name_suffix        = "webapp-server"
   elb_names          = [aws_elb.web.name]

--- a/examples/vpc-scenario-2/main.tf
+++ b/examples/vpc-scenario-2/main.tf
@@ -166,7 +166,6 @@ resource "aws_elb" "web" {
 module "web" {
   source        = "../../modules/asg"
   ami           = module.ubuntu-xenial-ami.id
-  azs           = local.azs
   name_prefix   = "${var.name}-web"
   elb_names     = [aws_elb.web.name]
   instance_type = "t2.nano"

--- a/examples/vpc-scenario-3/main.tf
+++ b/examples/vpc-scenario-3/main.tf
@@ -139,7 +139,6 @@ resource "aws_elb" "web" {
 module "web" {
   source        = "../../modules/asg"
   ami           = module.ubuntu-xenial-ami.id
-  azs           = local.azs
   name_prefix   = "${var.name}-web"
   elb_names     = [aws_elb.web.name]
   instance_type = "t2.nano"

--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -24,7 +24,6 @@
  */
 # Auto-Scaling Group
 resource "aws_autoscaling_group" "cluster" {
-  availability_zones        = var.azs
   force_delete              = true
   health_check_grace_period = 300
   health_check_type         = var.health_check_type

--- a/modules/asg/variables.tf
+++ b/modules/asg/variables.tf
@@ -59,11 +59,6 @@ variable "public_ip" {
   type        = string
 }
 
-variable "azs" {
-  description = "list of availability zones to associate with the ASG"
-  type        = list(string)
-}
-
 variable "subnet_ids" {
   description = "list of subnets to associate with the ASG (by id)"
   type        = list(string)

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -6,7 +6,6 @@ module "asg" {
   source = "../modules/asg"
 
   ami                = ""
-  azs                = []
   key_name           = ""
   max_nodes          = ""
   min_nodes          = ""


### PR DESCRIPTION
This PR removes availability_zones from the asg module, as https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html says availability_zones and vpc_zone_identifier should not be used together causing issue #242, it is also important to note that availability_zones is required to use EC2-Classic, so this update will make terraform-aws-foundation possibly not work on EC2-Classic