### PR TITLE
modules/stp-m-infra: Add iam:Get{User,Role,Policy} for power-users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Modules
 
+* `setup-meta-infrastructure`: add "iam:Get{User,Role,Policy}" permissions for power-users
 * `iam-instance-profile`: Add role ouput for IAM instance profile module.
 * lifecycle hooks added to `asg` and so `asg-lifecycle` was removed
 

--- a/modules/setup-meta-infrastructure/policies.tf
+++ b/modules/setup-meta-infrastructure/policies.tf
@@ -82,6 +82,9 @@ data "aws_iam_policy_document" "power-user-with-mfa" {
     actions = [
       "iam:ListAccount*",
       "iam:GetAccount*",
+      "iam:GetUser",
+      "iam:GetRole",
+      "iam:GetPolicy",
       "iam:ListUsers",
       "iam:ListRoles",
       "organizations:DescribeOrganization",
@@ -121,6 +124,9 @@ data "aws_iam_policy_document" "power-user-no-mfa" {
     actions = [
       "iam:ListAccount*",
       "iam:GetAccount*",
+      "iam:GetUser",
+      "iam:GetRole",
+      "iam:GetPolicy",
       "iam:ListUsers",
       "iam:ListRoles",
       "organizations:DescribeOrganization",


### PR DESCRIPTION
Background:
The power-user role may have access to change, modify all parts of the
infrastructure except only all IAM related configuration. In certain
situations, like having to modify S3 buckets created by it's own user
the "iam:Get{User,Role,Policy}" permissions become necessary.

This commit grants only those three permission to the power-user role,
or, members of that group.

-----
- [X] Update the changelog
- [X] Make sure that modules and files are documented. This can be done inside the module and files.
- [X] Make sure that new modules directories contain a basic README.md file.
- [X] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [X] Make sure that the linting passes on CI.
- [X] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [X] Make sure that there is a manual CI trigger that can test the deployment.
