### PR TITLE
asg module: Default value for variable key_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   You will need to _manually_ remove the conflicting route (which was created
   by the old inline route), for example in the AWS console, and then re-apply
   to add it back.
+* `asg`: Add default value for `key_name`. The default value is an
+  empty string which indicates the instance in the ASG has no key
+  associated with it.
 
 ### Examples
 

--- a/modules/asg/variables.tf
+++ b/modules/asg/variables.tf
@@ -10,6 +10,7 @@ variable "name_suffix" {
 }
 
 variable "key_name" {
+  default     = ""
   description = "The name of the (AWS) SSH key to associate with the instance"
   type        = string
 }


### PR DESCRIPTION
The default value is an empty string which indicates the instance in
the ASG has no key associated with it. This makes the key to be optionally passed when using the module.

Please also note that these are not hard requirements, but merely serve to define
what maintainers are looking for in PR's.  Including these will more likely lead 
to your PR being reviewed and accepted.

- [x] Update the changelog
- [x] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.
