### PR TITLE
Small update for the changelog for a v0.9.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,64 @@
 
 ### Summary
 
+
 ### Modules
 
-* `setup-meta-infrastructure`: add "iam:Get{User,Role,Policy}" permissions for power-users
-* `iam-instance-profile`: Add role ouput for IAM instance profile module.
+
+### Examples
+
+
+# v0.9.7
+
+### Summary
+
+* Updates to `asg` and `vpc` modules, new example for AD w/ Windows Server.
+
+### Modules
+
+* `asg`: drop `availability_zones` parameter.
+* `vpc`: Added variable `domain_name` to enable setting a custom domain_name
+  in the VPC DHCP Options Set.
+
+### Examples
+
+* `ad-ec2`: Demonstrate how an Windows EC2 instance seamlessly joins an Active
+  directory when it gets newly spawned.
+
+
+# v0.9.6
+
+### Summary
+
+* New module: `tf-cloud-credentials`.
+* Updates to DLM and other modules.
+
+### Modules
+
+* `tf-cloud-credentials`: Adds module for associating existing AWS credentials
+  with a Terraform Cloud workspace.
+* `dlm-lifecycle-iam-role`: Added DLM IAM role to allow create snapshots
+* `dlm-lifecycle-policy`: Update DML module to tf 0.12 and move the IAM role to another role
+* Module to enable DML lifecycle policies
+* Revert removing output `asg_iam_role_name`
+* Bugfix for `persistent-ebs`
+
+### Examples
+
+* No changes.
+
+
+# v0.9.5
+
+### Summary
+
+* Various updates to the `setup-meta-infrastructure`, `asg`, and `nat-gateways`
+  modules.
+
+### Modules
+
+* `setup-meta-infrastructure`: add "iam:Get{User,Role,Policy}" permissions for
+  power-users.
 * lifecycle hooks added to `asg` and so `asg-lifecycle` was removed
 * `nat-gateways`: **Breaking change**: move the inline route route in the route
   table to a separate route, so that users of the module can add extra routes
@@ -14,26 +68,26 @@
   You will need to _manually_ remove the conflicting route (which was created
   by the old inline route), for example in the AWS console, and then re-apply
   to add it back.
-* `vpc`: Added variable `domain_name` to enable setting a custom domain_name
-  in the VPC DHCP Options Set.
 
 ### Examples
 
-* `ad-ec2`: Demonstrate how an Windows EC2 instance seamlessly joins an Active directory when it gets newly spawned.
-* `ad-asg-different-vpc`: Demonstrate how an Windows EC2 instance in a
-  specific vpc seamlessly joins an Active directory (in a different
-  vpc) when it gets newly spawned.
+* No changes.
 
 
-# v0.9.6
+# v0.9.4
 
 ### Summary
 
-* New module for associating existing AWS credentials with a Terraform Cloud workspace.
+* Update `iam-instance-profile` module.
 
 ### Modules
 
-* `tf-cloud-credentials`: Adds module
+* `iam-instance-profile`: Add role ouput for IAM instance profile module.
+
+### Examples
+
+* No changes.
+
 
 # v0.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@
   specific vpc seamlessly joins an Active directory (in a different
   vpc) when it gets newly spawned.
 
+
+# v0.9.6
+
+### Summary
+
+* New module for associating existing AWS credentials with a Terraform Cloud workspace.
+
+### Modules
+
+* `tf-cloud-credentials`: Adds module
+
 # v0.9.3
 
 ### Summary


### PR DESCRIPTION
- [x] Update the changelog

This is a small PR that serves to update the changelog to mention the `tf-cloud-credentials` module added in https://github.com/fpco/terraform-aws-foundation/pull/264 and the new `v0.9.6` release. 

This PR contributes to https://github.com/fpco/terraform-aws-foundation/issues/248