### PR TITLE
WIP: Add an output for the role arn to the single-node-asg module.

### DIFF
--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -91,4 +91,5 @@ module "init-attach-ebs" {
   source = "../init-snippet-attach-ebs-volume"
   region = var.region
   volume_id = module.service-data.volume_id
+  device_path = var.ebs_device_path
 }

--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -57,13 +57,12 @@ module "server" {
   source = "../asg"
 
   ami       = var.ami
-  azs       = [local.az]
   elb_names = var.load_balancers
   key_name  = var.key_name
   # The IAM Instance Profile w/ attach_ebs role
   iam_profile   = module.instance_profile.iam_profile_id
   instance_type = var.instance_type
-  # 1 EC2 instance <> 1 EBS volume 
+  # 1 EC2 instance <> 1 EBS volume
   max_nodes       = 1
   min_nodes       = 1
   placement_group = var.placement_group

--- a/modules/single-node-asg/outputs.tf
+++ b/modules/single-node-asg/outputs.tf
@@ -3,6 +3,11 @@ output "asg_name" {
   description = "`name` exported from the Server `aws_autoscaling_group`"
 }
 
+output "asg_iam_role_arn" {
+  value       = module.instance_profile.iam_role_arn
+  description = "The Role ARN of the instance profile associated with the instance in the ASG"
+}
+
 output "asg_iam_role_name" {
   value       = module.instance_profile.iam_role_name
   description = "`name` exported from the Service Data `aws_iam_role`"

--- a/modules/single-node-asg/variables.tf
+++ b/modules/single-node-asg/variables.tf
@@ -77,6 +77,12 @@ variable "data_volume_iops" {
   type        = string
 }
 
+variable "ebs_device_path" {
+  default     = "/dev/xvdf"
+  description = "Path to the device's path in /dev/ that will be passed to the init-snippet-attach-ebs-volume module. You may need to use /dev/nvme1n1 or similar for nitro-based instance types"
+  type = string
+}
+
 variable "init_prefix" {
   default     = ""
   description = "init shell to run before setting VOLUME_ID and REGION exports"


### PR DESCRIPTION
- This PR adds the `asg_iam_role_arn` output to the `single-node-asg` module
- This PR also makes a fix for the `single-node-asg` module by removing the `azs` variable which is no longer a part of the parent `asg` module since https://github.com/fpco/terraform-aws-foundation/pull/247

---

- [ ] Update the changelog
- [x] Make sure that modules and files are documented. This can be done inside the module and files.
- [x] Make sure that new modules directories contain a basic README.md file.
- [x] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.
