### PR TITLE
Fix iam-users output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Modules
 
+* `iam-users`: fixed error from zipmap in outputs when a user gets deleted
+  from user list
 
 ### Examples
 

--- a/modules/iam-users/main.tf
+++ b/modules/iam-users/main.tf
@@ -16,5 +16,5 @@ resource "aws_iam_user" "u" {
 
 output "users" {
   description = "The list of IAM user objects that exist"
-  value       = zipmap(var.user_list, aws_iam_user.u.*)
+  value       = zipmap(var.user_list, slice(aws_iam_user.u.*, 0, length(var.user_list)))
 }


### PR DESCRIPTION
When a user gets deleted from user list Terraform will fail
creating a plan complaining that number of keys doesn't match
number of values.
Th solution is taken from https://github.com/terraform-google-modules/terraform-google-cloud-storage/pull/23/files

Example error seen:
```
  19:   value       = zipmap(var.user_list, aws_iam_user.u.*)
    |----------------
    | aws_iam_user.u is tuple with 8 elements
    | var.user_list is list of string with 7 elements

Call to function "zipmap" failed: number of keys (7) does not match number of
values (8).
```
