### PR TITLE
Remove deprecated interpolation-only exprs from tf-cloud-credential

### DIFF
--- a/modules/tf-cloud-credential/main.tf
+++ b/modules/tf-cloud-credential/main.tf
@@ -1,5 +1,5 @@
 resource "tfe_variable" "workspace_aws_access_key_id" {
-  workspace_id = "${tfe_workspace.workspace.id}"
+  workspace_id = tfe_workspace.workspace.id
   key          = "AWS_ACCESS_KEY_ID"
   value        = var.iam_access_key.id
   category     = "env"
@@ -7,7 +7,7 @@ resource "tfe_variable" "workspace_aws_access_key_id" {
 }
 
 resource "tfe_variable" "workspace_aws_secret_access_key_id" {
-  workspace_id = "${tfe_workspace.workspace.id}"
+  workspace_id = tfe_workspace.workspace.id
   key          = "AWS_SECRET_ACCESS_KEY"
   value        = var.iam_access_key.secret
   category     = "env"
@@ -15,7 +15,7 @@ resource "tfe_variable" "workspace_aws_secret_access_key_id" {
 }
 
 resource "tfe_variable" "workspace_aws_default_region" {
-  workspace_id = "${tfe_workspace.workspace.id}"
+  workspace_id = tfe_workspace.workspace.id
   key          = "AWS_DEFAULT_REGION"
   value        = var.region
   category     = "env"

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -721,6 +721,15 @@ module "subnets" {
   vpc_id      = ""
 }
 
+module "tf-cloud-credential" {
+  source = "../modules/tf-cloud-credential"
+  
+  name_prefix    = ""
+  organization   = ""
+  iam_access_key = { id = "", secret = "" }
+  region         = ""
+}  
+
 module "vpc" {
   source = "../modules/vpc"
 


### PR DESCRIPTION
This is more or less trivial fix and it will remove a lot of deprecation warnings in our terraform runs
