### PR TITLE
module init-snippet-attach-ebs-volume: Retrying attaching EBS

### DIFF
--- a/modules/init-snippet-attach-ebs-volume/snippet.tpl
+++ b/modules/init-snippet-attach-ebs-volume/snippet.tpl
@@ -4,10 +4,13 @@ export AWS_DEFAULT_REGION=${region}
 VOLUME_ID=${volume_id}
 INSTANCE_ID="$(ec2metadata --instance-id)"
 echo "${log_prefix} will attach $${VOLUME_ID} via the AWS API in ${region}"
-aws ec2 attach-volume                     \
+while ! aws ec2 attach-volume                     \
           --volume-id "$${VOLUME_ID}"     \
           --instance-id "$${INSTANCE_ID}" \
-          --device '${device_path}'
+          --device '${device_path}'; do
+  echo "Attaching command failed to run. Retrying."
+  sleep '${wait_interval}'
+done
 
 while ! ls '${device_path}'; do
   sleep '${wait_interval}'


### PR DESCRIPTION
In a rare case, the instance is running, but its AWS status is not "running". Then attaching process fails. The failure won't stop the instance hence ASG won't retry the whole process. This leaves us in an unexpected status.

This change is a patch up.


---
name: Pull request template
about: Make a PR to terraform-aws-foundation
---

Please include the following in your PR:

Please also note that these are not hard requirements, but merely serve to define
what maintainers are looking for in PR's.  Including these will more likely lead 
to your PR being reviewed and accepted.

- [ ] Update the changelog
- [ ] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.