### PR TITLE
using workspace_id

### DIFF
--- a/modules/tf-cloud-credential/data.tf
+++ b/modules/tf-cloud-credential/data.tf
@@ -1,4 +1,0 @@
-data "tfe_workspace" "workspace" {
-  name         = var.name_prefix
-  organization = var.organization
-}

--- a/modules/tf-cloud-credential/main.tf
+++ b/modules/tf-cloud-credential/main.tf
@@ -1,5 +1,5 @@
 resource "tfe_variable" "workspace_aws_access_key_id" {
-  workspace_id = data.tfe_workspace.workspace.id
+  workspace_id = var.workspace_id
   key          = "AWS_ACCESS_KEY_ID"
   value        = var.iam_access_key.id
   category     = "env"
@@ -7,7 +7,7 @@ resource "tfe_variable" "workspace_aws_access_key_id" {
 }
 
 resource "tfe_variable" "workspace_aws_secret_access_key_id" {
-  workspace_id = data.tfe_workspace.workspace.id
+  workspace_id = var.workspace_id
   key          = "AWS_SECRET_ACCESS_KEY"
   value        = var.iam_access_key.secret
   category     = "env"
@@ -15,7 +15,7 @@ resource "tfe_variable" "workspace_aws_secret_access_key_id" {
 }
 
 resource "tfe_variable" "workspace_aws_default_region" {
-  workspace_id = data.tfe_workspace.workspace.id
+  workspace_id = var.workspace_id
   key          = "AWS_DEFAULT_REGION"
   value        = var.region
   category     = "env"

--- a/modules/tf-cloud-credential/variables.tf
+++ b/modules/tf-cloud-credential/variables.tf
@@ -1,11 +1,6 @@
-variable "name_prefix" {
+variable "workspace_id" {
   type        = string
-  description = "The name prefix to use for the workspace"
-}
-
-variable "organization" {
-  type        = string
-  description = "The workspace organization"
+  description = "Id of workspace to put variables in."
 }
 
 variable "iam_access_key" {


### PR DESCRIPTION
Changes tf-cloud-credential so that it receives the workspace_id as an argument instead of searching it with a datasource, because the datasource brings problems when the workspace does not exists