### PR TITLE
Switch up how targets groups are associated with the ASG

### DIFF
--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -29,7 +29,6 @@ resource "aws_autoscaling_group" "cluster" {
   health_check_type         = var.health_check_type
   launch_configuration      = aws_launch_configuration.cluster.name
   load_balancers            = var.elb_names
-  target_group_arns         = var.alb_target_group_arns
   max_size                  = var.max_nodes
   min_size                  = var.min_nodes
   name_prefix               = "${var.name_prefix}-${var.name_suffix}"
@@ -110,4 +109,11 @@ resource "aws_launch_configuration" "cluster" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+# Attach ASG to the load balancer target group
+resource "aws_autoscaling_attachment" "main" {
+  count                  = length(var.alb_target_group_arns)
+  autoscaling_group_name = aws_autoscaling_group.cluster.name
+  alb_target_group_arn   = var.alb_target_group_arns.main[count.index]
 }

--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -115,5 +115,5 @@ resource "aws_launch_configuration" "cluster" {
 resource "aws_autoscaling_attachment" "main" {
   count                  = length(var.alb_target_group_arns)
   autoscaling_group_name = aws_autoscaling_group.cluster.name
-  alb_target_group_arn   = var.alb_target_group_arns.main[count.index]
+  alb_target_group_arn   = var.alb_target_group_arns[count.index]
 }


### PR DESCRIPTION
Small change to how we associate target groups with the ASG in the `asg` module

- [ ] Update the changelog
- [ ] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.
