### PR TITLE
A few changes to (mostly) single-node-asg module.

### DIFF
--- a/modules/init-snippet-attach-ebs-volume/snippet.tpl
+++ b/modules/init-snippet-attach-ebs-volume/snippet.tpl
@@ -11,8 +11,15 @@ while ! aws ec2 attach-volume                     \
   echo "Attaching command failed to run. Retrying."
   sleep '${wait_interval}'
 done
+echo "${log_prefix} $${VOLUME_ID} attached."
 
-while ! ls '${device_path}'; do
-  sleep '${wait_interval}'
+vol_id="$(echo "$${VOLUME_ID}" | tr -d '-')"
+while [ ! -e /dev/disk/by-id/*-Amazon_Elastic_Block_Store_$${vol_id} ]; do
+  sleep '${wait_interval}' 
 done
+
+dev_id="$(ls /dev/disk/by-id/*-Amazon_Elastic_Block_Store_$${vol_id} | head -1)"
+dev_name="/dev/$(readlink "$${dev_id}" | tr / '\n' | tail -1)"
+[ "$${dev_name}" == "${device_path}" ] || ln -s "$${dev_name}" "${device_path}"
+
 ${init_suffix}

--- a/modules/init-snippet-attach-ebs-volume/snippet.tpl
+++ b/modules/init-snippet-attach-ebs-volume/snippet.tpl
@@ -2,7 +2,7 @@
 ${init_prefix}
 export AWS_DEFAULT_REGION=${region}
 VOLUME_ID=${volume_id}
-INSTANCE_ID="$(ec2metadata --instance-id)"
+INSTANCE_ID="$(wget -O- http://169.254.169.254/latest/meta-data/instance-id || curl http://169.254.169.254/latest/meta-data/instance-id)"
 echo "${log_prefix} will attach $${VOLUME_ID} via the AWS API in ${region}"
 while ! aws ec2 attach-volume                     \
           --volume-id "$${VOLUME_ID}"     \

--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -72,10 +72,11 @@ module "server" {
   name_prefix = var.name_prefix
   name_suffix = "${var.name_suffix}-${local.az}"
 
-  root_volume_type   = var.root_volume_type
-  root_volume_size   = var.root_volume_size
-  security_group_ids = var.security_group_ids
-  subnet_ids         = [var.subnet_id]
+  root_volume_type      = var.root_volume_type
+  root_volume_size      = var.root_volume_size
+  security_group_ids    = var.security_group_ids
+  subnet_ids            = [var.subnet_id]
+  alb_target_group_arns = var.alb_target_group_arns
 
   user_data = <<END_INIT
 #!/bin/bash
@@ -88,7 +89,7 @@ END_INIT
 
 # Render init snippet - boxed module to attach the EBS volume to the node
 module "init-attach-ebs" {
-  source = "../init-snippet-attach-ebs-volume"
-  region = var.region
+  source    = "../init-snippet-attach-ebs-volume"
+  region    = var.region
   volume_id = module.service-data.volume_id
 }

--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -80,6 +80,9 @@ module "server" {
 
   user_data = <<END_INIT
 #!/bin/bash
+# exec > /tmp/init.log
+# exec 2> /tmp/init-err.log
+# set -x
 ${var.init_prefix}
 ${module.init-attach-ebs.init_snippet}
 ${var.init_suffix}

--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -72,11 +72,10 @@ module "server" {
   name_prefix = var.name_prefix
   name_suffix = "${var.name_suffix}-${local.az}"
 
-  root_volume_type      = var.root_volume_type
-  root_volume_size      = var.root_volume_size
-  security_group_ids    = var.security_group_ids
-  subnet_ids            = [var.subnet_id]
-  alb_target_group_arns = var.alb_target_group_arns
+  root_volume_type   = var.root_volume_type
+  root_volume_size   = var.root_volume_size
+  security_group_ids = var.security_group_ids
+  subnet_ids         = [var.subnet_id]
 
   user_data = <<END_INIT
 #!/bin/bash

--- a/modules/single-node-asg/outputs.tf
+++ b/modules/single-node-asg/outputs.tf
@@ -7,3 +7,8 @@ output "asg_iam_role_name" {
   value       = module.instance_profile.iam_role_name
   description = "`name` exported from the Service Data `aws_iam_role`"
 }
+
+output "data_volume_name_tag" {
+  value       = "${local.data_volume_name_prefix}-${local.az}"
+  description = "Name tag value for attached data volume"
+}

--- a/modules/single-node-asg/variables.tf
+++ b/modules/single-node-asg/variables.tf
@@ -115,9 +115,3 @@ variable "load_balancers" {
   description = "The list of load balancers names to pass to the ASG module"
   type        = list(string)
 }
-
-variable "alb_target_group_arns" {
-  default     = []
-  description = "list of target_group for application load balancer to associate with the ASG (by ARN)"
-  type        = list(string)
-}

--- a/modules/single-node-asg/variables.tf
+++ b/modules/single-node-asg/variables.tf
@@ -116,3 +116,8 @@ variable "load_balancers" {
   type        = list(string)
 }
 
+variable "alb_target_group_arns" {
+  default     = []
+  description = "list of target_group for application load balancer to associate with the ASG (by ARN)"
+  type        = list(string)
+}


### PR DESCRIPTION
While making confluence example, a few changes are needed:

Enable attach ELB to single node ASG. `single-node-asg` does not take ELB target group yet.

Remove dependency of Ubuntu on single-node-asg EBS attaching script. `ec2metadata` command exists only in Ubuntu AMI, and latest version for CentOS from AWS, not only has different name, but also output differently. So using raw http request to get rid of it.

Ensure EBS attachment ends up the device name we want.

Module/single-node-asg: Output attached data volume tag value "Name" so DLM can match the tag to manage the snapshots.

---
name: Pull request template
about: Make a PR to terraform-aws-foundation
---

Please include the following in your PR:

Please also note that these are not hard requirements, but merely serve to define
what maintainers are looking for in PR's.  Including these will more likely lead 
to your PR being reviewed and accepted.

- [ ] Update the changelog
- [ ] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.
