### PR TITLE
Add kms to s3 remote state module

### DIFF
--- a/modules/s3-full-access-policy/main.tf
+++ b/modules/s3-full-access-policy/main.tf
@@ -50,11 +50,12 @@ data "aws_iam_policy_document" "s3-full-access" {
     effect = "Allow"
 
     actions = [
-      "s3:ListObjects",
+      # "s3:ListObjects", # TODO this might not be a valid action
+      # See https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html
       "s3:PutObject",
       "s3:GetObject",
       "s3:DeleteObject",
-      "s3:CreateMultipartUpload",
+      # "s3:CreateMultipartUpload", # TODO this might not be a valid action
       "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
     ]

--- a/modules/s3-remote-state/main.tf
+++ b/modules/s3-remote-state/main.tf
@@ -35,11 +35,25 @@ variable "force_destroy" {
   type        = bool
 }
 
+variable "kms_key_id" {
+  description = "The ARN of a KMS Key to use for encrypting the state"
+  type        = string
+}
+
 resource "aws_s3_bucket" "remote-state" {
   bucket        = var.bucket_name
   acl           = "private"
   region        = var.region
   force_destroy = var.force_destroy
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = var.kms_key_id
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
 
   versioning {
     enabled = var.versioning

--- a/modules/s3-remote-state/main.tf
+++ b/modules/s3-remote-state/main.tf
@@ -13,7 +13,6 @@ variable "bucket_name" {
 }
 
 variable "principals" {
-  default     = []
   description = "list of user/role ARNs to get full access to the bucket"
   type        = list(string)
 }
@@ -72,8 +71,6 @@ data "aws_iam_policy_document" "s3-full-access" {
   statement {
     effect = "Allow"
 
-    # find an authoritative list of valid Actions for a AWS bucket policy,
-    # I haven't been able to locate one, and the two commented out are invalid
     actions = [
       "s3:PutObject",
       "s3:GetObject",


### PR DESCRIPTION
Initial attempt to add server side encryption to the `s3-remote-state` module to support 

https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#server_side_encryption_configuration

for https://www.terraform.io/docs/backends/types/s3.html#kms_key_id

Contributes to https://github.com/fpco/terraform-aws-foundation/issues/310

- [ ] Update the changelog
- [ ] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.
