### PR TITLE
add alb_target_group_arns to parameters

### DIFF
--- a/modules/single-node-asg/main.tf
+++ b/modules/single-node-asg/main.tf
@@ -77,6 +77,8 @@ module "server" {
   security_group_ids = var.security_group_ids
   subnet_ids         = [var.subnet_id]
 
+  alb_target_group_arns = var.alb_target_group_arns
+
   user_data = <<END_INIT
 #!/bin/bash
 # exec > /tmp/init.log

--- a/modules/single-node-asg/variables.tf
+++ b/modules/single-node-asg/variables.tf
@@ -115,3 +115,9 @@ variable "load_balancers" {
   description = "The list of load balancers names to pass to the ASG module"
   type        = list(string)
 }
+
+variable "alb_target_group_arns" {
+  default     = []
+  description = "list of target_group for application load balancer to associate with the ASG (by ARN)"
+  type        = list(string)
+}


### PR DESCRIPTION
---
name: add alb_target_group_arns to parameters
about: adds alb_target_group_arns as a parameter to single-node-asg
---

Right now the aws provider has problems tracking the state of the aws_autoscaling_attachment which causes a that each time a plan is made terraform will detect a change even though no chage has been made.

try for example [test1.txt](https://github.com/fpco/terraform-aws-foundation/files/4394424/test1.txt) and [test2.txt](https://github.com/fpco/terraform-aws-foundation/files/4394427/test2.txt). 

for the test1 project (which uses terraform-aws-foundation//modules/asg in the way terraform-aws-foundation//modules/single-node-asg does) after applying the plan once and trying again you get the change:

```
      ~ target_group_arns         = [
          - "arn:aws:elasticloadbalancing:us-west-2:793514493597:targetgroup/test1-https-tg/a60467b421465538",
        ]
```

applying again you get

```
Terraform will perform the following actions:

  # aws_autoscaling_attachment.asg_alb will be created
  + resource "aws_autoscaling_attachment" "asg_alb" {
      + alb_target_group_arn   = "arn:aws:elasticloadbalancing:us-west-2:793514493597:targetgroup/test1-https-tg/a60467b421465538"
      + autoscaling_group_name = "jose-cluster20200327111722994700000003"
      + id                     = (known after apply)
    }
```

applying yet again it returns to the first change and applying will loop between the two changes

test2 on the other hand does uses correctly the alb_target_group_arns parameter and no changes are detected after applying once.

To fix that create destroy loop with single-node-asg we just need a small patch to pass that parameter down to asg module