### PR TITLE
Fix quoted type variable in the dlm module

### DIFF
--- a/modules/dlm-lifecycle-policy/variables.tf
+++ b/modules/dlm-lifecycle-policy/variables.tf
@@ -1,6 +1,6 @@
 variable "name_prefix" {
   description = "Name to prefix the DML lifecycle"
-  type        = "string"
+  type        = string
 }
 
 variable "ebs_target_tags" {
@@ -59,7 +59,7 @@ variable "policy_copy_tags" {
 
 variable "policy_tags_to_add" {
   description = "Tags to add to the snapshot"
-  type        = "map"
+  type        = map
   default     = {"SnapshotCreator" = "DLM lifecycle"}
 }
 


### PR DESCRIPTION
This is a small fix for a deprecation warning we frequently see when using the dlm-lifecycle-policy module:

```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/<REDACTED>/modules/dlm-lifecycle-policy/variables.tf line 3, in variable "name_prefix":
   3:   type        = "string"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "string".

(and one more similar warning elsewhere)
```

- [ ] Update the changelog
- [ ] Make sure that modules and files are documented. This can be done inside the module and files.
- [ ] Make sure that new modules directories contain a basic README.md file.
- [ ] Make sure that the module is added to [tests/main.tf](https://github.com/fpco/terraform-aws-foundation/blob/master/tests/main.tf)
- [ ] Make sure that the linting passes on CI.
- [ ] Make sure that there is an up to date example for your code:
      - For new `modules` this would entail example code for how to use the module or some explanation in the module readme.
      - For new examples please provide a README explaining how to run the example. It's also ideal to provide a basic makefile to use the example as well.
- [ ] Make sure that there is a manual CI trigger that can test the deployment.
