### PR TITLE
r53-subdomain: vpc block should be dyanamic, for when zone is public

### DIFF
--- a/modules/r53-subdomain/main.tf
+++ b/modules/r53-subdomain/main.tf
@@ -22,14 +22,21 @@ variable "ttl" {
 }
 
 variable "vpc_id" {
-  description = "The VPC ID to associate a private zone with (leave blank for public zone)"
+  description = "The VPC ID to associate a private zone with (leave blank for public zone), use assocations for linking multiple VPCs"
   default     = ""
   type        = string
 }
 
 resource "aws_route53_zone" "subdomain" {
   name   = var.name
-  vpc_id = var.vpc_id
+
+  dynamic "vpc" {
+    for_each = [var.vpc_id]
+
+    content {
+      vpc_id = var.vpc_id
+    }
+  }
 }
 
 resource "aws_route53_record" "subdomain-NS" {


### PR DESCRIPTION
This update uses dynamic blocks from Terraform 0.12 to allow the `r53-subdomain` module to work with both private and public zones. With Terraform 0.11, an empty `vpc_id` would not error out but with 0.12, the `vpc` block should not exist if the `vpc_id` param would be empty.