### PR TITLE
ami-centos: added new aws provided images and ami_name parameter to p…

### DIFF
--- a/modules/ami-centos/README.md
+++ b/modules/ami-centos/README.md
@@ -5,16 +5,19 @@ release of Centos. Use it like:
 
 ```
 module "centos-7-ami" {
-  source  = "../../modules/ami-centos"
+  source         = "../../modules/ami-centos"
+  release        = 7
+  image_provider = "CentOS"
 }
 ```
 
 Or:
 
 ```
-module "centos-6-ami" {
-  source  = "../../modules/ami-centos"
-  release = "6"
+module "centos-8-ami" {
+  source         = "../../modules/ami-centos"
+  release        = 8
+  image_provider = "AWS"
 }
 ```
 
@@ -22,7 +25,7 @@ To use the AMI on EC2, reference it by ID like this: `${module.centos-7-ami.id}`
 
 The module will filter the AMI by the following criteria:
 
-* provided by Centos.org
+* provided by Centos.org or AWS
 * the most recent release
 * hvm-type AMIs
 * amd64

--- a/modules/ami-centos/main.tf
+++ b/modules/ami-centos/main.tf
@@ -6,7 +6,20 @@ variable "most_recent" {
 
 variable "release" {
   description = "default centos release to target"
+  type        = number
+  validation {
+    condition     = var.release >= 6 && var.release <= 8
+    error_message = "CentOS version number (6 | 7 | 8)."
+  }
+}
+
+variable "image_provider" {
+  description = "The image provider (AWS | CentOS)."
   type        = string
+  validation {
+    condition     = var.image_provider == "CentOS" || var.image_provider == "AWS"
+    error_message = "The provider value must be either \"CentOS\" or \"AWS\"."
+  }
 }
 
 data "aws_ami" "centos" {
@@ -26,20 +39,28 @@ data "aws_ami" "centos" {
   # we can be sure of the ami's authenticity by filtering by the products id's unique to
   # CentOS.org, which can be found on their web site at https://wiki.centos.org/Cloud/AWS
   filter {
-    name   = "product-code"
-    values = [
-      "aw0evgkw8e5c1q413zgy5pjce", # Official `CentOS 7 (x86_64) - with Updates HVM` product id
-      "6x5jmcajty9edm3f211pqjfn2"  # Official `CentOS 6 (x86_64) - with Updates HVM` product id
-    ]
+    name = "product-code"
+    values = compact(var.image_provider == "AWS" ? [
+      var.release == 8 ? "47k9ia2igxpcce2bzo8u3kj03" : "", # Official `CentOS 8 (x86_64) - with Updates HVM` by AWS product id
+      var.release == 7 ? "cvugziknvmxgqna9noibqnnsy" : "", # Official `CentOS 7 (x86_64) - with Updates HVM` by AWS product id
+      var.release == 6 ? "ckx0h8ljio731afm2k92jtg62" : ""  # Official `CentOS 6 (x86_64) - with Updates HVM` by AWS product id
+      ] : [
+      var.release == 7 ? "aw0evgkw8e5c1q413zgy5pjce" : "", # Official `CentOS 7 (x86_64) - with Updates HVM` by CentOS product id
+      var.release == 6 ? "6x5jmcajty9edm3f211pqjfn2" : ""  # Official `CentOS 6 (x86_64) - with Updates HVM` by CentOS product id
+    ])
   }
 
   owners = ["679593333241"]
 
-  name_regex = "^CentOS Linux ${var.release} x86_64 HVM EBS ENA"
 }
 
 output "id" {
   value       = data.aws_ami.centos.id
   description = "ID of the AMI"
+}
+
+output "name" {
+  value       = data.aws_ami.centos.name
+  description = "Name of the AMI"
 }
 

--- a/modules/ami-centos/versions.tf
+++ b/modules/ami-centos/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13" # minimun level has to be 0.13 because of validations.
 }


### PR DESCRIPTION
Closes #331

This MR adds the new AWS provided images to ami-centos module.

The search by regex was removed, new aws images had different names to the old centos images, but using the product codes this regex can be remove and makes the search a bit faster.